### PR TITLE
fix(qa): correct tokei tool pattern and add summary output

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,7 +22,7 @@
     {
       "name": "devx-qa",
       "description": "Quality assurance toolkit to analyze your codebase, review code, and manage CLAUDE.md memory",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "author": {
         "name": "Pierre Tomasina",
         "email": "contact@dev3o.com"

--- a/plugins/qa/.claude-plugin/plugin.json
+++ b/plugins/qa/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "devx-qa",
   "description": "Quality assurances toolkit to analyse deeply your codebase, review the code and basic security check",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "author": {
     "name": "Pierre Tomasina",
     "email": "contact@dev3o.com"

--- a/plugins/qa/commands/explain.md
+++ b/plugins/qa/commands/explain.md
@@ -1,7 +1,7 @@
 ---
 description: Analyze project architecture with ASCII state machine and sequence diagrams
 argument-hint: [feature-or-entrypoint]
-allowed-tools: Bash(tokei:*,find:*,wc:*,cat:*,head:*), Read, Grep, Glob
+allowed-tools: Bash(tokei), Read, Grep, Glob
 ---
 
 # Project Explain
@@ -10,9 +10,9 @@ Target: $ARGUMENTS
 
 ## Step 1: Analyze Project Composition
 
-Run tokei for language statistics (fallback to file counting if unavailable):
-
-!`tokei --output json 2>/dev/null || tokei 2>/dev/null || (echo "tokei not found, counting files:" && find . -type f \( -name "*.ts" -o -name "*.js" -o -name "*.py" -o -name "*.go" -o -name "*.rs" -o -name "*.java" \) 2>/dev/null | head -50 | xargs wc -l 2>/dev/null | tail -5)`
+Get language statistics by running tokei: !`tokei || echo 'not installed'`
+If tokei is not installed, use Glob to count files by extension (*.ts, *.js, *.py, *.go, *.rs, *.java) and estimate project composition from the results.
+**Include language statistics results in the Summary**
 
 Detect package manifests and read the first one found:
 - `package.json` for Node.js dependencies


### PR DESCRIPTION
## Summary
- Fixed tokei bash tool pattern from `tokei:*` to `tokei` for proper command execution
- Simplified tokei fallback logic and added explicit instruction to display language statistics summary
- Bumped devx-qa version to 1.0.1

## Test plan
- [x] Run `/devx-qa:explain` on a TypeScript project and verify tokei output is displayed with language statistics summary
- [x] Verify command works on projects without tokei installed (uses Glob fallback)