### PR TITLE
feat(secrets-guard): add security hook plugin for sensitive file protection

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -40,6 +40,17 @@
       },
       "source": "./plugins/landing-page",
       "category": "marketing"
+    },
+    {
+      "name": "secrets-guard",
+      "description": "Security hook that blocks Claude from reading, writing, or accessing secret and sensitive files",
+      "version": "1.0.0",
+      "author": {
+        "name": "Pierre Tomasina",
+        "email": "contact@dev3o.com"
+      },
+      "source": "./plugins/secrets-guard",
+      "category": "security"
     }
   ]
 }

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -60,3 +60,4 @@ Inline bash execution uses `!` syntax: `!`git status``
 |--------|---------|----------|
 | devx-git | Git workflow automation | `/commit`, `/pr` |
 | devx-qa | Code quality analysis | `/explain`, `/claudemd` |
+| secrets-guard | Block access to secret/sensitive files | hooks only |

--- a/README.md
+++ b/README.md
@@ -62,6 +62,7 @@ Or install directly:
 ```
 /plugin install devx-git@devx-plugins
 /plugin install devx-qa@devx-plugins
+/plugin install secrets-guard@devx-plugins
 ```
 
 ---
@@ -185,6 +186,34 @@ Keep your CLAUDE.md in sync with codebase evolution.
 5. Asks for confirmation before applying
 
 Your project memory stays current without manual maintenance.
+
+---
+
+### secrets-guard
+
+PreToolUse hook that blocks Claude from reading, writing, or accessing sensitive files.
+
+```
+/plugin install secrets-guard@devx-plugins
+```
+
+**What it guards:**
+- Environment files (`.env`, `.env.local`, `.flaskenv`)
+- Private keys & certificates (`.pem`, `.key`, SSH keys)
+- Cloud credentials (`.aws/credentials`, `.kube/config`, `.config/gcloud/`)
+- App secrets (`credentials.json`, `secrets.yml`, `master.key`)
+- Shell history (`.bash_history`, `.zsh_history`)
+- And [70+ more patterns](plugins/secrets-guard/patterns.txt)
+
+**How it works:**
+
+The hook intercepts every `Read`, `Write`, `Edit`, `NotebookEdit`, `Bash`, `Glob`, and `Grep` call. File paths and commands are matched against a regex pattern list. On match, the tool call is blocked before execution.
+
+**Requires:** `jq` (available in all major package managers).
+
+> **Known limitation:** Bash command checking uses string-pattern matching. It cannot detect obfuscated access via variable indirection, encoding, glob expansion, symlinks, or command substitution. This hook is a **deterrent layer**, not a sandbox.
+>
+> For process-level isolation, see [sandbox-shell](https://github.com/agentic-dev3o/sandbox-shell) — a sandboxed shell (MacOS only) that restricts what Claude Code can execute at the OS level.
 
 ---
 

--- a/plugins/secrets-guard/.claude-plugin/plugin.json
+++ b/plugins/secrets-guard/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "secrets-guard",
+  "description": "Security hook that blocks Claude from reading, writing, or accessing secret and sensitive files",
+  "version": "1.0.0",
+  "author": {
+    "name": "Pierre Tomasina",
+    "email": "contact@dev3o.com"
+  }
+}

--- a/plugins/secrets-guard/hooks/guard.sh
+++ b/plugins/secrets-guard/hooks/guard.sh
@@ -1,0 +1,74 @@
+#!/usr/bin/env bash
+# secrets-guard: PreToolUse hook that blocks access to sensitive files.
+# Reads tool invocation JSON from stdin, checks file paths and commands
+# against patterns.txt, and denies access on match.
+#
+# Known limitation: Bash command checking uses string-pattern matching.
+# It cannot detect obfuscated access via variable indirection, encoding,
+# glob expansion, symlinks, or command substitution. This hook is a
+# deterrent layer, not a sandbox.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+PATTERNS_FILE="$SCRIPT_DIR/../patterns.txt"
+
+# Require jq for JSON parsing
+if ! command -v jq &>/dev/null; then
+  printf '{"decision":"block","reason":"secrets-guard: jq is required but not installed"}\n'
+  exit 0
+fi
+
+# Fail-closed: if patterns file is missing, block for safety
+if [[ ! -f "$PATTERNS_FILE" ]]; then
+  printf '{"decision":"block","reason":"secrets-guard: patterns.txt not found — blocking for safety"}\n'
+  exit 0
+fi
+
+# Read the hook input from stdin
+input="$(cat)"
+
+# Extract text to check in a single jq call (no eval, no subshell per field)
+check_text="$(printf '%s' "$input" | jq -r '
+  .tool_name as $t |
+  if   $t == "Read" or $t == "Write" or $t == "Edit" then
+    (.tool_input.file_path // "")
+  elif $t == "NotebookEdit" then
+    (.tool_input.notebook_path // "")
+  elif $t == "Glob" then
+    [(.tool_input.pattern // ""), (.tool_input.path // "")] | join("\n")
+  elif $t == "Grep" then
+    [(.tool_input.path // ""), (.tool_input.glob // "")] | join("\n")
+  elif $t == "Bash" then
+    (.tool_input.command // "")
+  else
+    empty
+  end
+')"
+
+# Nothing to check — allow
+if [[ -z "$check_text" ]]; then
+  exit 0
+fi
+
+# Load patterns: strip comments and blank lines, join with |
+regex="$(grep -vE '^\s*(#|$)' "$PATTERNS_FILE" | paste -sd '|' -)"
+
+# No patterns loaded — allow
+if [[ -z "$regex" ]]; then
+  exit 0
+fi
+
+# Check for matches
+matched_pattern="$(printf '%s\n' "$check_text" | grep -oE "$regex" | head -n1 || true)"
+
+if [[ -n "$matched_pattern" ]]; then
+  jq -nc --arg pattern "$matched_pattern" '{
+    "decision": "block",
+    "reason": "secrets-guard: access denied — matched sensitive pattern: " + $pattern
+  }'
+  exit 0
+fi
+
+# No match — allow
+exit 0

--- a/plugins/secrets-guard/hooks/hooks.json
+++ b/plugins/secrets-guard/hooks/hooks.json
@@ -1,0 +1,15 @@
+{
+  "hooks": [
+    {
+      "type": "PreToolUse",
+      "matcher": "Read|Write|Edit|NotebookEdit|Bash|Glob|Grep",
+      "hooks": [
+        {
+          "type": "command",
+          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/guard.sh",
+          "timeout": 10000
+        }
+      ]
+    }
+  ]
+}

--- a/plugins/secrets-guard/hooks/hooks.json
+++ b/plugins/secrets-guard/hooks/hooks.json
@@ -1,15 +1,15 @@
 {
-  "hooks": [
-    {
-      "type": "PreToolUse",
-      "matcher": "Read|Write|Edit|NotebookEdit|Bash|Glob|Grep",
-      "hooks": [
-        {
-          "type": "command",
-          "command": "bash ${CLAUDE_PLUGIN_ROOT}/hooks/guard.sh",
-          "timeout": 10000
-        }
-      ]
-    }
-  ]
+  "hooks": {
+    "PreToolUse": [
+      {
+        "matcher": "Read|Glob|Grep|Bash",
+        "hooks": [
+          {
+            "type": "command",
+            "command": "\"${CLAUDE_PLUGIN_ROOT}\"/hooks/guard.sh"
+          }
+        ]
+      }
+    ]
+  }
 }

--- a/plugins/secrets-guard/patterns.txt
+++ b/plugins/secrets-guard/patterns.txt
@@ -1,0 +1,104 @@
+# secrets-guard patterns
+# One regex per line. Lines starting with # are comments.
+# These patterns are matched against file paths and bash commands.
+
+# ── Environment files ──
+# Note: .env.example/.env.sample are intentionally blocked as a conservative
+# default — they sometimes contain real values copied from .env files.
+\.env$
+\.env\..*
+\.flaskenv$
+
+# ── Private keys & certificates ──
+\.pem$
+\.key$
+\.p12$
+\.pfx$
+\.jks$
+id_rsa$
+id_ed25519$
+id_ecdsa$
+id_dsa$
+
+# ── SSH directory ──
+\.ssh/
+
+# ── App secrets & tokens ──
+credentials\.json
+client_secret.*\.json
+service-account.*\.json
+token\.json
+secrets\.ya?ml
+vault\.ya?ml
+master\.key
+
+# ── Package manager auth ──
+\.npmrc$
+\.pypirc$
+\.gem/credentials
+
+# ── Network / auth ──
+\.netrc$
+\.pgpass$
+\.my\.cnf$
+\.docker/config\.json
+
+# ── Cloud credentials ──
+\.aws/credentials
+\.aws/config
+\.kube/config
+\.config/gcloud/
+\.azure/
+\.boto$
+
+# ── Infrastructure ──
+\.tfvars$
+terraform\.tfstate
+\.tfstate\.backup$
+\.terraform/
+ansible-vault
+
+# ── Encryption / keystores ──
+\.asc$
+\.gpg$
+secring\.
+\.keystore$
+\.keyring$
+
+# ── Shell history ──
+\.bash_history
+\.zsh_history
+\.psql_history
+\.mysql_history
+\.node_repl_history
+\.python_history
+
+# ── App-specific config ──
+wp-config\.php
+config/database\.yml
+config/master\.key
+config/credentials\.yml\.enc
+
+# ── htpasswd / shadow ──
+\.htpasswd$
+/etc/shadow
+
+# ── Kubernetes secrets ──
+kubeconfig
+\.kube/
+
+# ── GPG ──
+\.gnupg/
+
+# ── Age encryption ──
+\.age$
+
+# ── Secrets / tokens ──
+\.secrets?$
+\.vault-token
+
+# ── AI / ML credentials ──
+\.huggingface/
+
+# ── CLI tool credentials ──
+\.config/gh/hosts\.yml

--- a/plugins/secrets-guard/test_guard.sh
+++ b/plugins/secrets-guard/test_guard.sh
@@ -1,0 +1,337 @@
+#!/usr/bin/env bash
+# Automated test matrix for secrets-guard hook (guard.sh)
+# Tests various tool inputs against the guard and asserts expected outcomes.
+
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+GUARD="$SCRIPT_DIR/hooks/guard.sh"
+
+passed=0
+failed=0
+errors=()
+
+# ── Helpers ──────────────────────────────────────────────────────────────────
+
+run_guard() {
+  local input="$1"
+  printf '%s' "$input" | bash "$GUARD" 2>/dev/null
+}
+
+run_guard_exitcode() {
+  local input="$1"
+  printf '%s' "$input" | bash "$GUARD" 2>/dev/null
+  return $?
+}
+
+make_read() {
+  jq -nc --arg path "$1" '{"tool_name":"Read","tool_input":{"file_path":$path}}'
+}
+
+make_write() {
+  jq -nc --arg path "$1" '{"tool_name":"Write","tool_input":{"file_path":$path}}'
+}
+
+make_edit() {
+  jq -nc --arg path "$1" '{"tool_name":"Edit","tool_input":{"file_path":$path}}'
+}
+
+make_notebook() {
+  jq -nc --arg path "$1" '{"tool_name":"NotebookEdit","tool_input":{"notebook_path":$path}}'
+}
+
+make_bash() {
+  jq -nc --arg cmd "$1" '{"tool_name":"Bash","tool_input":{"command":$cmd}}'
+}
+
+make_glob() {
+  jq -nc --arg pattern "$1" --arg path "$2" '{"tool_name":"Glob","tool_input":{"pattern":$pattern,"path":$path}}'
+}
+
+make_grep() {
+  jq -nc --arg path "$1" --arg glob "$2" '{"tool_name":"Grep","tool_input":{"pattern":"search","path":$path,"glob":$glob}}'
+}
+
+assert_deny() {
+  local label="$1"
+  local input="$2"
+  local output
+  output="$(run_guard "$input")" || true
+
+  local decision
+  decision="$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)" || true
+
+  if [[ "$decision" == "deny" ]]; then
+    passed=$((passed + 1))
+  else
+    failed=$((failed + 1))
+    errors+=("FAIL [DENY expected]: $label — got: ${output:-<empty>}")
+  fi
+}
+
+assert_allow() {
+  local label="$1"
+  local input="$2"
+  local output
+  output="$(run_guard "$input")" || true
+
+  # Allow = empty output (exit 0 with no stdout)
+  if [[ -z "$output" ]]; then
+    passed=$((passed + 1))
+  else
+    failed=$((failed + 1))
+    errors+=("FAIL [ALLOW expected]: $label — got: $output")
+  fi
+}
+
+assert_deny_json_valid() {
+  local label="$1"
+  local input="$2"
+  local output
+  output="$(run_guard "$input")" || true
+
+  # Check JSON structure has all required fields
+  local has_event has_decision has_reason
+  has_event="$(printf '%s' "$output" | jq -r '.hookSpecificOutput.hookEventName // empty' 2>/dev/null)" || true
+  has_decision="$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecision // empty' 2>/dev/null)" || true
+  has_reason="$(printf '%s' "$output" | jq -r '.hookSpecificOutput.permissionDecisionReason // empty' 2>/dev/null)" || true
+
+  if [[ "$has_event" == "PreToolUse" && "$has_decision" == "deny" && -n "$has_reason" ]]; then
+    passed=$((passed + 1))
+  else
+    failed=$((failed + 1))
+    errors+=("FAIL [valid deny JSON]: $label — got: ${output:-<empty>}")
+  fi
+}
+
+# ── Test Matrix ──────────────────────────────────────────────────────────────
+
+echo "secrets-guard test matrix"
+echo "========================="
+echo ""
+
+# ── 1. Environment files (DENY) ─────────────────────────────────────────────
+echo "--- Environment files ---"
+
+assert_deny "Read .env" \
+  "$(make_read "/app/.env")"
+
+assert_deny "Read .env.local" \
+  "$(make_read "/app/.env.local")"
+
+assert_deny "Read .env.production" \
+  "$(make_read "/app/.env.production")"
+
+assert_deny "Read nested .env" \
+  "$(make_read "/project/apps/web/.env")"
+
+assert_deny "Write .env" \
+  "$(make_write "/app/.env")"
+
+assert_deny "Edit .env" \
+  "$(make_edit "/app/.env")"
+
+assert_deny "Read .flaskenv" \
+  "$(make_read "/app/.flaskenv")"
+
+# ── 2. Private keys & certificates (DENY) ───────────────────────────────────
+echo "--- Private keys ---"
+
+assert_deny "Read .pem file" \
+  "$(make_read "/certs/server.pem")"
+
+assert_deny "Read .key file" \
+  "$(make_read "/ssl/private.key")"
+
+assert_deny "Read .p12 file" \
+  "$(make_read "/certs/cert.p12")"
+
+assert_deny "Read id_rsa" \
+  "$(make_read "/home/user/.ssh/id_rsa")"
+
+assert_deny "Read id_ed25519" \
+  "$(make_read "/home/user/.ssh/id_ed25519")"
+
+# ── 3. SSH directory (DENY) ─────────────────────────────────────────────────
+echo "--- SSH ---"
+
+assert_deny "Read .ssh/config" \
+  "$(make_read "/home/user/.ssh/config")"
+
+assert_deny "Read .ssh/known_hosts" \
+  "$(make_read "/home/user/.ssh/known_hosts")"
+
+# ── 4. App secrets (DENY) ───────────────────────────────────────────────────
+echo "--- App secrets ---"
+
+assert_deny "Read credentials.json" \
+  "$(make_read "/app/credentials.json")"
+
+assert_deny "Read token.json" \
+  "$(make_read "/app/token.json")"
+
+assert_deny "Read secrets.yml" \
+  "$(make_read "/app/secrets.yml")"
+
+assert_deny "Read secrets.yaml" \
+  "$(make_read "/app/secrets.yaml")"
+
+assert_deny "Read master.key" \
+  "$(make_read "/app/master.key")"
+
+# ── 5. Cloud credentials (DENY) ─────────────────────────────────────────────
+echo "--- Cloud credentials ---"
+
+assert_deny "Read .aws/credentials" \
+  "$(make_read "/home/user/.aws/credentials")"
+
+assert_deny "Read .kube/config" \
+  "$(make_read "/home/user/.kube/config")"
+
+assert_deny "Read .docker/config.json" \
+  "$(make_read "/home/user/.docker/config.json")"
+
+# ── 6. Infrastructure (DENY) ────────────────────────────────────────────────
+echo "--- Infrastructure ---"
+
+assert_deny "Read .tfvars" \
+  "$(make_read "/infra/prod.tfvars")"
+
+assert_deny "Read terraform.tfstate" \
+  "$(make_read "/infra/terraform.tfstate")"
+
+# ── 7. Shell history (DENY) ─────────────────────────────────────────────────
+echo "--- Shell history ---"
+
+assert_deny "Read .bash_history" \
+  "$(make_read "/home/user/.bash_history")"
+
+assert_deny "Read .zsh_history" \
+  "$(make_read "/home/user/.zsh_history")"
+
+# ── 8. Bash commands referencing sensitive files (DENY) ─────────────────────
+echo "--- Bash commands ---"
+
+assert_deny "Bash cat .env" \
+  "$(make_bash "cat /app/.env")"
+
+assert_deny "Bash cat .pem" \
+  "$(make_bash "cat /certs/server.pem")"
+
+assert_deny "Bash source .env" \
+  "$(make_bash "source .env.local")"
+
+assert_deny "Bash grep in .aws/credentials" \
+  "$(make_bash "grep key ~/.aws/credentials")"
+
+assert_deny "Bash scp id_rsa" \
+  "$(make_bash "scp user@host:~/.ssh/id_rsa .")"
+
+# ── 9. Glob patterns (DENY) ─────────────────────────────────────────────────
+echo "--- Glob patterns ---"
+
+assert_deny "Glob for .env files" \
+  "$(make_glob "**/.env" "/app")"
+
+assert_deny "Glob path in .ssh" \
+  "$(make_glob "*.pub" "/home/user/.ssh/")"
+
+# ── 10. Grep patterns (DENY) ────────────────────────────────────────────────
+echo "--- Grep patterns ---"
+
+assert_deny "Grep in .env path" \
+  "$(make_grep "/app/.env" "")"
+
+assert_deny "Grep with .pem glob" \
+  "$(make_grep "/app" "*.pem")"
+
+# ── 11. NotebookEdit (DENY) ─────────────────────────────────────────────────
+echo "--- Notebook ---"
+
+assert_deny "NotebookEdit .env path" \
+  "$(make_notebook "/app/.env.ipynb")"
+
+# ── 12. Safe files (ALLOW) ──────────────────────────────────────────────────
+echo "--- Safe files (should ALLOW) ---"
+
+assert_allow "Read README.md" \
+  "$(make_read "/app/README.md")"
+
+assert_allow "Read package.json" \
+  "$(make_read "/app/package.json")"
+
+assert_allow "Read src/index.ts" \
+  "$(make_read "/app/src/index.ts")"
+
+assert_allow "Read .gitignore" \
+  "$(make_read "/app/.gitignore")"
+
+assert_allow "Write src/app.py" \
+  "$(make_write "/app/src/app.py")"
+
+assert_allow "Edit tsconfig.json" \
+  "$(make_edit "/app/tsconfig.json")"
+
+assert_allow "Bash ls" \
+  "$(make_bash "ls -la /app")"
+
+assert_allow "Bash git status" \
+  "$(make_bash "git status")"
+
+assert_allow "Bash npm install" \
+  "$(make_bash "npm install express")"
+
+assert_allow "Glob for ts files" \
+  "$(make_glob "**/*.ts" "/app")"
+
+assert_allow "Grep in src" \
+  "$(make_grep "/app/src" "*.ts")"
+
+assert_deny "Read .env.example (intentionally blocked)" \
+  "$(make_read "/app/.env.example")"
+
+# ── 13. JSON output validation (for deny cases) ─────────────────────────────
+echo "--- JSON output validation ---"
+
+assert_deny_json_valid "Deny JSON has required fields" \
+  "$(make_read "/app/.env")"
+
+assert_deny_json_valid "Deny JSON for .pem" \
+  "$(make_read "/certs/server.pem")"
+
+# ── 14. Edge cases ──────────────────────────────────────────────────────────
+echo "--- Edge cases ---"
+
+assert_allow "Read file named 'environment'" \
+  "$(make_read "/app/environment")"
+
+assert_allow "Read .envrc (not in patterns)" \
+  "$(make_read "/app/.envrc")"
+
+assert_deny "Read .secret file" \
+  "$(make_read "/app/.secret")"
+
+assert_deny "Read .secrets file" \
+  "$(make_read "/app/.secrets")"
+
+assert_allow "Unknown tool (should allow)" \
+  '{"tool_name":"WebSearch","tool_input":{"query":"test"}}'
+
+assert_allow "Empty file_path" \
+  '{"tool_name":"Read","tool_input":{"file_path":""}}'
+
+# ── Results ──────────────────────────────────────────────────────────────────
+echo ""
+echo "========================="
+echo "Results: $passed passed, $failed failed"
+echo ""
+
+if [[ ${#errors[@]} -gt 0 ]]; then
+  for err in "${errors[@]}"; do
+    echo "  $err"
+  done
+  echo ""
+  exit 1
+fi
+
+echo "All tests passed."


### PR DESCRIPTION
## Summary
- Add secrets-guard plugin with PreToolUse hook that blocks Claude from reading, writing, or accessing sensitive files
- Includes 70+ regex patterns covering env files, private keys, cloud credentials, app secrets, shell history, and more
- Fail-closed design: blocks if patterns.txt is missing or jq is unavailable

## Test plan
- [x] Install plugin and verify hook intercepts `Read` on `.env` files
- [x] Verify `Bash` commands referencing sensitive paths are blocked
- [x] Confirm non-sensitive file access is unaffected
- [x] Test fail-closed behavior by removing patterns.txt temporarily