### PR TITLE
feat(qa): add react anti-pattern auditing skill

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -22,7 +22,7 @@
     {
       "name": "devx-qa",
       "description": "Quality assurance toolkit to analyze your codebase, review code, and manage CLAUDE.md memory",
-      "version": "1.0.1",
+      "version": "1.2.0",
       "author": {
         "name": "Pierre Tomasina",
         "email": "contact@dev3o.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -54,7 +54,7 @@ Inline bash execution uses `!` syntax: `!`git status``
 | Plugin | Purpose | Commands |
 |--------|---------|----------|
 | devx-git | Git workflow automation | `/commit`, `/pr` (skills) |
-| devx-qa | Architecture analysis & skill improvement | `/explaining-architecture`, `/skill-fixer` (skills) |
+| devx-qa | Architecture analysis, skill improvement & React auditing | `/explaining-architecture`, `/skill-fixer`, `/fixing-react-antipatterns` (skills) |
 | secrets-guard | Block access to secret/sensitive files | hooks only |
 | landing-page | Structured copywriting & Astro 5 landing pages | `/writing-landing-page-copy`, `/building-landing-page` (skills) |
 | devx-ralph | Predicate-driven agentic loop | `/plan`, `/ralph`, `/archive`, `/analyze` (skill) |

--- a/plugins/qa/.claude-plugin/plugin.json
+++ b/plugins/qa/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "devx-qa",
   "description": "Quality assurances toolkit to analyse deeply your codebase, review the code and basic security check",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "author": {
     "name": "Pierre Tomasina",
     "email": "contact@dev3o.com"

--- a/plugins/qa/README.md
+++ b/plugins/qa/README.md
@@ -50,6 +50,27 @@ Evaluates and improves a plugin's skills by applying Anthropic's skill authoring
 
 ---
 
+### fixing-react-antipatterns
+
+Audits React codebases for anti-patterns (useEffect misuse, missing cleanup, stale closures, memory leaks) and produces a scored gap analysis table with severity ratings. Applies prioritized fixes on request.
+
+```
+audit react code
+fix react anti-patterns
+check useEffect cleanup in src/components/
+```
+
+**What happens:**
+1. Runs `scan-antipatterns.sh` to inventory suspect patterns
+2. Reads flagged files and classifies findings by category and severity
+3. Produces a gap analysis table grouped by: useEffect rules, state management, component architecture, cleanup & memory safety, navigation & DOM
+4. Applies fixes in priority order (if requested)
+5. Verifies with lint
+
+Includes three reference files with authoritative rules and before/after fix examples.
+
+---
+
 ### claudemd
 
 Keeps CLAUDE.md in sync with codebase evolution. Triggers when you ask to update or sync CLAUDE.md.

--- a/plugins/qa/skills/react-fixer/SKILL.md
+++ b/plugins/qa/skills/react-fixer/SKILL.md
@@ -1,0 +1,155 @@
+---
+name: react-fixer
+description: >-
+  This skill should be used when the user asks to "fix react anti-patterns",
+  "audit react code", "find useEffect misuse", "check react performance",
+  "review react hooks", "scan for react issues", "clean up react components",
+  "fix memory leaks in react", "check useEffect cleanup", "find stale closures",
+  or wants to identify and fix common React anti-patterns in a codebase.
+  Produces a scored gap analysis table with severity ratings and prioritized fixes.
+---
+
+# React Fixer
+
+Audit React codebases for anti-patterns that degrade performance, cause memory leaks,
+or reduce maintainability. Produce a gap analysis table and apply fixes.
+
+Target: `$ARGUMENTS` (path to scan, defaults to `src/`)
+
+## Workflow
+
+Progress checklist:
+
+```
+React Anti-Pattern Audit:
+- [ ] Step 1: Scan for anti-patterns
+- [ ] Step 2: Classify findings
+- [ ] Step 3: Produce gap analysis table
+- [ ] Step 4: Apply fixes (if requested)
+- [ ] Step 5: Verify with lint
+```
+
+### Step 1: Scan for Anti-Patterns
+
+Run `scripts/scan-antipatterns.sh` against the target directory to get a quick
+inventory of suspect patterns. Then read flagged files to confirm true positives.
+
+Use the Explore agent for deeper analysis when the script flags ambiguous cases.
+
+### Step 2: Classify Findings
+
+For each confirmed finding, assign exactly one category from the rules in
+`references/useeffect-patterns.md`, `references/component-patterns.md`, or
+`references/cleanup-patterns.md`.
+
+Severity levels:
+- **HIGH** — Memory leaks, infinite loops, data loss, security (e.g. uncleaned timers, stale closure causing wrong data)
+- **MEDIUM** — Extra render cycles, obscured dependencies, poor readability (e.g. useEffect for derived state, inline map logic)
+- **LOW** — Style or minor perf (e.g. inline arrow in static list, missing useCallback on trivial handler)
+
+### Step 3: Produce Gap Analysis Table
+
+Output a markdown table with these columns:
+
+| Practice | Status | Severity | File:Line | Evidence |
+|----------|--------|----------|-----------|----------|
+
+Status values: **Respected**, **Violated**, **Partially respected**, **N/A**
+
+Group rows by category:
+1. useEffect rules
+2. State management
+3. Component architecture
+4. Cleanup & memory safety
+5. Navigation & DOM
+
+End with a **Score summary** per category (X/10) and a **Top fixes** list ordered by impact.
+
+### Step 4: Apply Fixes
+
+When the user requests fixes, apply them in priority order. For each fix:
+
+1. Read the file and surrounding context
+2. Apply the minimal change — no over-engineering, no unrelated refactors
+3. Preserve existing code style (semicolons, quotes, imports)
+
+Common fix patterns — consult reference files for detailed before/after examples:
+
+- **Derived state in useEffect** → Move to render-time `useMemo` or plain expression
+- **setTimeout without cleanup** → Wrap in `useEffect` with `clearTimeout` in return
+- **Inline map render logic** → Extract to a named component with props
+- **window.location.href** → Replace with `useNavigate()` from React Router
+- **Reactive state clearing** → Clear at the event source, not in a watching effect
+- **useCallback+useEffect indirection** → Inline the logic in the effect with direct deps
+
+### Step 5: Verify
+
+Run lint (`bun run lint` or project-specific command) after applying fixes.
+Confirm no regressions by checking that modified components still render correctly.
+
+## Anti-Pattern Categories (Quick Reference)
+
+Summary for classification. Authoritative rules with code examples live in the reference files.
+
+### useEffect Rules
+
+| Rule | Description |
+|------|-------------|
+| External sync only | Effects for I/O, timers, subscriptions — never for derived state |
+| No mirror state | Never `useEffect(() => setState(transform(props)), [props])` |
+| Cleanup required | Every timer, listener, or subscription needs a return cleanup |
+| Minimal deps | Deps should be primitives or memoized refs; no inline objects |
+| No reactive clearing | Do not clear state X by watching state Y in an effect |
+
+### State Management
+
+| Rule | Description |
+|------|-------------|
+| Derive during render | Compute values inline or with `useMemo`, not effect+setState |
+| useMemo for expensive ops | Map/Set creation, filtering large arrays, complex computation |
+| useCallback strategically | Only for callbacks passed to memoized children or as effect deps |
+| No prop mirroring | Do not copy props into state unless editing a form (document why) |
+
+### Component Architecture
+
+| Rule | Description |
+|------|-------------|
+| Extract map callbacks | Complex `.map()` render logic → named child component |
+| Single Responsibility | One concern per component; split God components |
+| Stable event handlers | Use `useCallback` or ref pattern to avoid stale closures |
+
+### Cleanup & Memory Safety
+
+| Rule | Description |
+|------|-------------|
+| setTimeout/setInterval | Always `clearTimeout`/`clearInterval` in effect cleanup |
+| AbortController | Use for raw `fetch()` calls; SDK-managed fetches are exempt |
+| No stale closures | Include all read values in deps or use ref escape hatch |
+
+### Navigation & DOM
+
+| Rule | Description |
+|------|-------------|
+| Router navigation | Use `useNavigate()`, never `window.location.href` for SPA routes |
+| DOM via refs | Imperative DOM access through `useRef`, not `document.querySelector` |
+
+## Additional Resources
+
+### Reference Files
+
+Consult these for detailed rules, before/after examples, and edge cases:
+- **`references/useeffect-patterns.md`** — Full useEffect rules with code examples
+- **`references/component-patterns.md`** — Extraction, memoization, SRP patterns
+- **`references/cleanup-patterns.md`** — Timer, listener, subscription cleanup
+
+### Scripts
+
+- **`scripts/scan-antipatterns.sh`** — Grep-based scanner for common anti-patterns
+
+## Constraints
+
+- Never add unrelated refactors alongside a fix
+- Preserve existing code style and conventions
+- Do not add comments, types, or docstrings to unchanged code
+- If a suppressed lint rule has a valid comment explaining intent, respect it
+- When in doubt about intent, flag the finding but do not auto-fix

--- a/plugins/qa/skills/react-fixer/SKILL.md
+++ b/plugins/qa/skills/react-fixer/SKILL.md
@@ -1,18 +1,14 @@
 ---
-name: react-fixer
+name: fixing-react-antipatterns
 description: >-
-  This skill should be used when the user asks to "fix react anti-patterns",
-  "audit react code", "find useEffect misuse", "check react performance",
-  "review react hooks", "scan for react issues", "clean up react components",
-  "fix memory leaks in react", "check useEffect cleanup", "find stale closures",
-  or wants to identify and fix common React anti-patterns in a codebase.
-  Produces a scored gap analysis table with severity ratings and prioritized fixes.
+  Audits React codebases for anti-patterns (useEffect misuse, missing cleanup,
+  stale closures, derived-state-in-effects, memory leaks) and produces a scored
+  gap analysis table with severity ratings. Applies prioritized fixes on request.
+  Triggers on: audit react code, fix react anti-patterns, review react hooks,
+  scan for react issues, check useEffect cleanup, fix memory leaks in react.
 ---
 
-# React Fixer
-
-Audit React codebases for anti-patterns that degrade performance, cause memory leaks,
-or reduce maintainability. Produce a gap analysis table and apply fixes.
+# Fixing React Anti-Patterns
 
 Target: `$ARGUMENTS` (path to scan, defaults to `src/`)
 
@@ -38,9 +34,11 @@ Use the Explore agent for deeper analysis when the script flags ambiguous cases.
 
 ### Step 2: Classify Findings
 
-For each confirmed finding, assign exactly one category from the rules in
-`references/useeffect-patterns.md`, `references/component-patterns.md`, or
-`references/cleanup-patterns.md`.
+For each confirmed finding, assign exactly one category using the authoritative rules
+and before/after examples in the reference files:
+- [references/useeffect-patterns.md](references/useeffect-patterns.md) — effect misuse, derived state, deps
+- [references/component-patterns.md](references/component-patterns.md) — extraction, memoization, SRP
+- [references/cleanup-patterns.md](references/cleanup-patterns.md) — timers, listeners, subscriptions, navigation
 
 Severity levels:
 - **HIGH** — Memory leaks, infinite loops, data loss, security (e.g. uncleaned timers, stale closure causing wrong data)
@@ -73,78 +71,12 @@ When the user requests fixes, apply them in priority order. For each fix:
 2. Apply the minimal change — no over-engineering, no unrelated refactors
 3. Preserve existing code style (semicolons, quotes, imports)
 
-Common fix patterns — consult reference files for detailed before/after examples:
-
-- **Derived state in useEffect** → Move to render-time `useMemo` or plain expression
-- **setTimeout without cleanup** → Wrap in `useEffect` with `clearTimeout` in return
-- **Inline map render logic** → Extract to a named component with props
-- **window.location.href** → Replace with `useNavigate()` from React Router
-- **Reactive state clearing** → Clear at the event source, not in a watching effect
-- **useCallback+useEffect indirection** → Inline the logic in the effect with direct deps
+Consult the reference files for detailed before/after examples of each fix pattern.
 
 ### Step 5: Verify
 
 Run lint (`bun run lint` or project-specific command) after applying fixes.
 Confirm no regressions by checking that modified components still render correctly.
-
-## Anti-Pattern Categories (Quick Reference)
-
-Summary for classification. Authoritative rules with code examples live in the reference files.
-
-### useEffect Rules
-
-| Rule | Description |
-|------|-------------|
-| External sync only | Effects for I/O, timers, subscriptions — never for derived state |
-| No mirror state | Never `useEffect(() => setState(transform(props)), [props])` |
-| Cleanup required | Every timer, listener, or subscription needs a return cleanup |
-| Minimal deps | Deps should be primitives or memoized refs; no inline objects |
-| No reactive clearing | Do not clear state X by watching state Y in an effect |
-
-### State Management
-
-| Rule | Description |
-|------|-------------|
-| Derive during render | Compute values inline or with `useMemo`, not effect+setState |
-| useMemo for expensive ops | Map/Set creation, filtering large arrays, complex computation |
-| useCallback strategically | Only for callbacks passed to memoized children or as effect deps |
-| No prop mirroring | Do not copy props into state unless editing a form (document why) |
-
-### Component Architecture
-
-| Rule | Description |
-|------|-------------|
-| Extract map callbacks | Complex `.map()` render logic → named child component |
-| Single Responsibility | One concern per component; split God components |
-| Stable event handlers | Use `useCallback` or ref pattern to avoid stale closures |
-
-### Cleanup & Memory Safety
-
-| Rule | Description |
-|------|-------------|
-| setTimeout/setInterval | Always `clearTimeout`/`clearInterval` in effect cleanup |
-| AbortController | Use for raw `fetch()` calls; SDK-managed fetches are exempt |
-| No stale closures | Include all read values in deps or use ref escape hatch |
-
-### Navigation & DOM
-
-| Rule | Description |
-|------|-------------|
-| Router navigation | Use `useNavigate()`, never `window.location.href` for SPA routes |
-| DOM via refs | Imperative DOM access through `useRef`, not `document.querySelector` |
-
-## Additional Resources
-
-### Reference Files
-
-Consult these for detailed rules, before/after examples, and edge cases:
-- **`references/useeffect-patterns.md`** — Full useEffect rules with code examples
-- **`references/component-patterns.md`** — Extraction, memoization, SRP patterns
-- **`references/cleanup-patterns.md`** — Timer, listener, subscription cleanup
-
-### Scripts
-
-- **`scripts/scan-antipatterns.sh`** — Grep-based scanner for common anti-patterns
 
 ## Constraints
 

--- a/plugins/qa/skills/react-fixer/references/cleanup-patterns.md
+++ b/plugins/qa/skills/react-fixer/references/cleanup-patterns.md
@@ -1,0 +1,194 @@
+# Cleanup & Memory Safety Patterns — Detailed Rules & Fixes
+
+## Rule 1: setTimeout / setInterval Must Be Cleaned Up
+
+Every `setTimeout` or `setInterval` that can outlive the component must have
+a corresponding `clearTimeout` / `clearInterval` in an effect cleanup.
+
+### Violation: Bare setTimeout in Event Handler
+
+```tsx
+// BAD — if component unmounts within 1500ms, setState runs on unmounted component
+const handleSubmit = async () => {
+  await saveData()
+  setSuccess(true)
+  setTimeout(() => {
+    setSuccess(false)
+    onClose()
+  }, 1500)
+}
+```
+
+### Fix Option A: Effect-Based Cleanup
+
+```tsx
+const [success, setSuccess] = useState(false)
+
+useEffect(() => {
+  if (!success) return
+  const id = setTimeout(() => {
+    setSuccess(false)
+    onClose()
+  }, 1500)
+  return () => clearTimeout(id)
+}, [success, onClose])
+
+const handleSubmit = async () => {
+  await saveData()
+  setSuccess(true)
+}
+```
+
+### Fix Option B: Ref-Based Cleanup
+
+```tsx
+const timerRef = useRef<ReturnType<typeof setTimeout>>(undefined)
+
+useEffect(() => {
+  return () => clearTimeout(timerRef.current)
+}, [])
+
+const handleSubmit = async () => {
+  await saveData()
+  setSuccess(true)
+  timerRef.current = setTimeout(() => {
+    setSuccess(false)
+    onClose()
+  }, 1500)
+}
+```
+
+### When Cleanup Is Truly Optional
+
+Short timeouts (< 500ms) in components that are never unmounted (root layout,
+persistent sidebar) are low risk. Still prefer cleanup for consistency.
+
+## Rule 2: Event Listeners
+
+Every `addEventListener` must have a matching `removeEventListener` in cleanup.
+
+```tsx
+// BAD — listener persists after unmount
+useEffect(() => {
+  window.addEventListener("resize", handleResize)
+}, [])
+```
+
+```tsx
+// GOOD
+useEffect(() => {
+  const handleResize = () => setWidth(window.innerWidth)
+  window.addEventListener("resize", handleResize)
+  return () => window.removeEventListener("resize", handleResize)
+}, [])
+```
+
+Define the handler inside the effect to guarantee the same function reference
+is used for both add and remove.
+
+## Rule 3: Subscriptions (WebSocket, EventSource, Observers)
+
+```tsx
+// GOOD — subscribe and unsubscribe in same effect
+useEffect(() => {
+  const ws = new WebSocket(url)
+  ws.onmessage = (e) => setMessages(prev => [...prev, JSON.parse(e.data)])
+  ws.onerror = (e) => setError(e)
+  return () => ws.close()
+}, [url])
+```
+
+For external store subscriptions, prefer `useSyncExternalStore`:
+
+```tsx
+import { useSyncExternalStore } from "react"
+
+function useChatCount(store: ChatStore) {
+  return useSyncExternalStore(
+    store.subscribe,
+    store.getSnapshot,
+    store.getSnapshot,
+  )
+}
+```
+
+## Rule 4: AbortController for Raw Fetch
+
+```tsx
+useEffect(() => {
+  const ac = new AbortController()
+  fetch(`/api/data/${id}`, { signal: ac.signal })
+    .then(r => r.json())
+    .then(setData)
+    .catch(e => {
+      if (e.name !== "AbortError") setError(e)
+    })
+  return () => ac.abort()
+}, [id])
+```
+
+### SDK-Managed Fetches Are Exempt
+
+These libraries handle cancellation internally:
+- Convex: `useQuery`, `useMutation`, `usePaginatedQuery`
+- React Query / TanStack Query: `useQuery`
+- SWR: `useSWR`
+- Apollo Client: `useQuery`
+
+Do not add AbortController when using these — it would be redundant.
+
+## Rule 5: Navigation — Use Router, Not window.location
+
+### Violation
+
+```tsx
+// BAD — full page reload, loses React state
+const handleImpersonate = async () => {
+  await authClient.admin.impersonateUser({ userId: user.id })
+  window.location.href = "/"
+}
+```
+
+### Fix
+
+```tsx
+// GOOD — SPA navigation, preserves state
+const navigate = useNavigate()
+
+const handleImpersonate = async () => {
+  await authClient.admin.impersonateUser({ userId: user.id })
+  navigate("/")
+}
+```
+
+### Exception
+
+`window.location.href` is acceptable when:
+- Navigating to a different origin (cross-domain redirect)
+- The entire app state must be reset (e.g., after session invalidation)
+- Navigating to a non-SPA backend route
+
+Document the reason when using `window.location.href` intentionally.
+
+## Rule 6: Clipboard API Error Handling
+
+```tsx
+// BAD — silent failure
+await navigator.clipboard.writeText(url)
+```
+
+```tsx
+// GOOD — inform user
+try {
+  await navigator.clipboard.writeText(url)
+  toast.success("Copied to clipboard")
+} catch {
+  toast.error("Failed to copy — check browser permissions")
+}
+```
+
+The Clipboard API can fail due to:
+- Missing browser permissions
+- Insecure context (HTTP, not HTTPS)
+- User denied permission prompt
+- Browser focus lost during operation

--- a/plugins/qa/skills/react-fixer/references/component-patterns.md
+++ b/plugins/qa/skills/react-fixer/references/component-patterns.md
@@ -1,0 +1,232 @@
+# Component Architecture Patterns — Detailed Rules & Fixes
+
+## Rule 1: Extract Complex Map Callbacks
+
+Inline `.map()` with conditionals, computed values, and branching should
+be extracted into named child components for readability, testability, and
+render isolation.
+
+### Violation: Inline Render Logic
+
+```tsx
+// BAD — complex logic inside map callback
+{messages.map((m) => {
+  const senderName = isBoundaryThread && m.role === "user" && m.creatorId
+    ? (userNameMap.get(m.creatorId) ?? "Unknown")
+    : null
+  const content = m.role === "assistant" && m.streamId && streamId === m.streamId
+    ? stream.text || "..."
+    : m.content || "..."
+
+  if (m.role === "assistant") {
+    return <div key={m._id}><p>{content}</p></div>
+  }
+  return (
+    <div key={m._id}>
+      {senderName && <p>{senderName}</p>}
+      <div><p>{content}</p></div>
+    </div>
+  )
+})}
+```
+
+### Fix: Extract to Component
+
+```tsx
+// GOOD — isolated component, React can skip re-renders for unchanged messages
+function MessageBubble({ message, isBoundaryThread, userNameMap, stream, streamId }: Props) {
+  const senderName = isBoundaryThread && message.role === "user" && message.creatorId
+    ? (userNameMap.get(message.creatorId) ?? "Unknown")
+    : null
+  const content = message.role === "assistant" && message.streamId && streamId === message.streamId
+    ? stream.text || "..."
+    : message.content || "..."
+
+  if (message.role === "assistant") {
+    return <div><p>{content}</p></div>
+  }
+  return (
+    <div>
+      {senderName && <p>{senderName}</p>}
+      <div><p>{content}</p></div>
+    </div>
+  )
+}
+
+// Parent becomes clean
+{messages.map((m) => (
+  <MessageBubble
+    key={m._id}
+    message={m}
+    isBoundaryThread={isBoundaryThread}
+    userNameMap={userNameMap}
+    stream={stream}
+    streamId={streamId}
+  />
+))}
+```
+
+### When to Extract
+
+Extract when the map callback:
+- Has conditional return statements (if/else branches)
+- Computes derived values from closure variables
+- Exceeds ~15 lines
+- Would benefit from `React.memo` for large lists
+
+Do NOT extract trivial maps like:
+```tsx
+{items.map(item => <li key={item.id}>{item.name}</li>)}
+```
+
+## Rule 2: Render Functions Inside Component Body
+
+```tsx
+// BAD — function recreated every render, captures closures
+function ChatSidebar({ threads, onViewChange, onStar }: Props) {
+  function renderThreadRow(t: Thread) {
+    return (
+      <div key={t._id} onClick={() => onViewChange({ kind: "chat", threadId: t._id })}>
+        <span>{t.title}</span>
+        <button onClick={() => onStar(t._id)}>Star</button>
+      </div>
+    )
+  }
+
+  return <div>{threads.map(renderThreadRow)}</div>
+}
+```
+
+```tsx
+// GOOD — separate component
+function ThreadRow({ thread, onViewChange, onStar }: ThreadRowProps) {
+  return (
+    <div onClick={() => onViewChange({ kind: "chat", threadId: thread._id })}>
+      <span>{thread.title}</span>
+      <button onClick={() => onStar(thread._id)}>Star</button>
+    </div>
+  )
+}
+
+function ChatSidebar({ threads, onViewChange, onStar }: Props) {
+  return (
+    <div>
+      {threads.map(t => (
+        <ThreadRow key={t._id} thread={t} onViewChange={onViewChange} onStar={onStar} />
+      ))}
+    </div>
+  )
+}
+```
+
+## Rule 3: Single Responsibility Principle
+
+Components should have one reason to change. Signs of a God component:
+- Multiple `useState` for unrelated concerns (form + dialog + fetch state)
+- Mix of data fetching, transformation, and rendering
+- File exceeds ~200 lines with multiple responsibilities
+
+### Fix: Split by Concern
+
+```tsx
+// BAD — one component handles everything
+function OrderPage() {
+  const [orders, setOrders] = useState([])
+  const [filter, setFilter] = useState("")
+  const [dialogOpen, setDialogOpen] = useState(false)
+  const [editingOrder, setEditingOrder] = useState(null)
+  // ... fetch logic, filter logic, dialog logic, render
+}
+```
+
+```tsx
+// GOOD — hook for data, components for concerns
+function useOrders(filter: string) {
+  // fetch + filter logic
+  return { orders, loading }
+}
+
+function OrderPage() {
+  const [filter, setFilter] = useState("")
+  const { orders, loading } = useOrders(filter)
+  return (
+    <>
+      <OrderFilter value={filter} onChange={setFilter} />
+      <OrderList orders={orders} loading={loading} />
+      <OrderEditDialog />
+    </>
+  )
+}
+```
+
+## Rule 4: Memoization Strategy
+
+### useMemo — When to Use
+
+Use `useMemo` for:
+- Converting arrays to Maps/Sets for O(1) lookups
+- Filtering/sorting large collections (100+ items)
+- Complex computations that depend on specific inputs
+- Values passed to memoized child components
+
+Do NOT use for:
+- Simple boolean expressions (`const isActive = status === "active"`)
+- String concatenation
+- Trivial array operations on small datasets
+
+### useCallback — When to Use
+
+Use `useCallback` for:
+- Async handlers passed as effect dependencies
+- Callbacks passed to `React.memo` children
+- Handlers used in `addEventListener`/`removeEventListener`
+
+Do NOT use for:
+- Inline `onClick` on native elements (button, div)
+- `onChange` on form inputs that are not memoized
+- One-off handlers that are not passed down
+
+### React.memo — When to Use
+
+Wrap a component in `React.memo` when:
+- It renders frequently due to parent re-renders
+- Its props rarely change
+- It is expensive to render (large DOM tree, complex calculations)
+
+Always profile before adding `React.memo` — premature memoization adds
+complexity without measurable benefit.
+
+## Rule 5: Stable Event Handlers
+
+### Stale Closure Problem
+
+```tsx
+// BAD — handler captures stale props
+function SaveButton({ onSave, payload }: Props) {
+  useEffect(() => {
+    window.addEventListener("keydown", handleKey)
+    return () => window.removeEventListener("keydown", handleKey)
+  }, []) // handleKey captures initial onSave/payload
+
+  const handleKey = (e: KeyboardEvent) => {
+    if (e.key === "s" && e.metaKey) onSave(payload) // stale!
+  }
+}
+```
+
+### Fix: Ref Pattern
+
+```tsx
+function SaveButton({ onSave, payload }: Props) {
+  const latest = useRef({ onSave, payload })
+  useEffect(() => { latest.current = { onSave, payload } })
+
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.key === "s" && e.metaKey) latest.current.onSave(latest.current.payload)
+    }
+    window.addEventListener("keydown", handleKey)
+    return () => window.removeEventListener("keydown", handleKey)
+  }, [])
+}
+```

--- a/plugins/qa/skills/react-fixer/references/useeffect-patterns.md
+++ b/plugins/qa/skills/react-fixer/references/useeffect-patterns.md
@@ -1,0 +1,193 @@
+# useEffect Anti-Patterns — Detailed Rules & Fixes
+
+## Rule 1: Effects Are for External Synchronization Only
+
+An effect should only sync with systems outside React: network, timers, DOM APIs,
+browser storage, subscriptions.
+
+### Violation: Derived State via Effect
+
+```tsx
+// BAD — effect mirrors props into state, causes double render
+function Orders({ orders, query }: Props) {
+  const [filtered, setFiltered] = useState<Order[]>([])
+  useEffect(() => {
+    setFiltered(orders.filter(o => o.title.includes(query)))
+  }, [orders, query])
+  return <List data={filtered} />
+}
+```
+
+```tsx
+// GOOD — derive during render
+function Orders({ orders, query }: Props) {
+  const filtered = useMemo(
+    () => orders.filter(o => o.title.includes(query)),
+    [orders, query],
+  )
+  return <List data={filtered} />
+}
+```
+
+When filtering is cheap (< 100 items), skip `useMemo` entirely:
+
+```tsx
+const filtered = orders.filter(o => o.title.includes(query))
+```
+
+### Violation: Reactive State Clearing
+
+```tsx
+// BAD — watches state Y to clear state X
+useEffect(() => {
+  if (!isLocked && error) setError(null)
+}, [isLocked, error])
+```
+
+```tsx
+// GOOD — clear at the event source
+const handleUnlock = async () => {
+  await unlockThread({ id: threadId })
+  setError(null) // clear here, not in an effect
+}
+```
+
+### Violation: Seeding Form State from Props
+
+```tsx
+// RISKY — boundary excluded from deps; stale if prop changes while open
+useEffect(() => {
+  if (open) {
+    setName(boundary?.name ?? "")
+    setDescription(boundary?.description ?? "")
+  }
+}, [open]) // boundary missing
+```
+
+```tsx
+// BETTER — include boundary, guard with key or explicit reset
+useEffect(() => {
+  if (open) {
+    setName(boundary?.name ?? "")
+    setDescription(boundary?.description ?? "")
+  }
+}, [open, boundary])
+
+// OR use key to remount: <Dialog key={boundary?._id} />
+```
+
+For form dialogs, including `boundary` in deps is acceptable. If edits should
+not be lost on prop change, document intent with a biome-ignore comment.
+
+## Rule 2: useCallback + useEffect Indirection
+
+```tsx
+// BAD — hides real dependencies behind function identity
+const fetchUsers = useCallback(async () => {
+  setLoading(true)
+  const { data } = await api.listUsers({ offset, search })
+  if (data) setUsers(data.users)
+  setLoading(false)
+}, [offset, search])
+
+useEffect(() => { fetchUsers() }, [fetchUsers])
+```
+
+```tsx
+// GOOD — inline the logic, deps are explicit
+useEffect(() => {
+  let cancelled = false
+  setLoading(true)
+  api.listUsers({ offset, search }).then(({ data }) => {
+    if (!cancelled && data) {
+      setUsers(data.users)
+      setTotal(data.total)
+    }
+    setLoading(false)
+  })
+  return () => { cancelled = true }
+}, [offset, search])
+```
+
+Keep `useCallback` when the function is also called from event handlers.
+Remove the indirection only when the callback exists solely to feed an effect.
+
+## Rule 3: Exhaustive Dependencies
+
+Always include every value read inside the effect. Suppress only with a clear
+comment explaining why the omission is intentional and safe.
+
+### Common Mistakes
+
+```tsx
+// BAD — stale count
+useEffect(() => {
+  if (count > 10) logAnalytics("high")
+}, []) // count missing
+
+// BAD — inline object identity changes every render
+useEffect(() => {
+  subscribe(options)
+  return () => unsubscribe(options)
+}, [options]) // if options = { a, b } created inline, effect reruns always
+```
+
+### Fixes
+
+```tsx
+// Include the dep
+useEffect(() => {
+  if (count > 10) logAnalytics("high")
+}, [count])
+
+// Memoize the object or destructure
+const stableOptions = useMemo(() => ({ a, b }), [a, b])
+useEffect(() => {
+  subscribe(stableOptions)
+  return () => unsubscribe(stableOptions)
+}, [stableOptions])
+```
+
+## Rule 4: Race Condition Prevention
+
+### Ignore Flag Pattern
+
+```tsx
+useEffect(() => {
+  let ignore = false
+  fetchUser(id).then(data => {
+    if (!ignore) setUser(data)
+  })
+  return () => { ignore = true }
+}, [id])
+```
+
+### AbortController Pattern
+
+```tsx
+useEffect(() => {
+  const ac = new AbortController()
+  fetch(`/api/users/${id}`, { signal: ac.signal })
+    .then(r => r.json())
+    .then(setUser)
+    .catch(e => { if (e.name !== "AbortError") setError(e) })
+  return () => ac.abort()
+}, [id])
+```
+
+Note: SDK-managed fetches (Convex `useQuery`, React Query, SWR) handle
+cancellation internally — AbortController is only needed for raw `fetch()`.
+
+## Rule 5: Ref Guards for Strict Mode Double-Runs
+
+```tsx
+// Prevent duplicate side effects in React 18 Strict Mode
+const initiated = useRef(false)
+useEffect(() => {
+  if (initiated.current) return
+  initiated.current = true
+  performOneTimeSetup()
+}, [])
+```
+
+Use sparingly — only for truly one-time operations (analytics, redirects).

--- a/plugins/qa/skills/react-fixer/scripts/scan-antipatterns.sh
+++ b/plugins/qa/skills/react-fixer/scripts/scan-antipatterns.sh
@@ -1,0 +1,104 @@
+#!/usr/bin/env bash
+# scan-antipatterns.sh — Quick grep-based scanner for common React anti-patterns
+# Usage: ./scan-antipatterns.sh [target_dir]
+#
+# Outputs flagged files with line numbers grouped by anti-pattern category.
+# False positives are expected — use this as a starting point for manual review.
+
+set -uo pipefail
+
+TARGET="${1:-.}"
+SEP="────────────────────────────────────────"
+
+rgsearch() {
+  rg "$@" --glob '*.ts' --glob '*.tsx' --glob '*.jsx' --glob '*.js' 2>/dev/null
+}
+
+echo "React Anti-Pattern Scanner"
+echo "Target: $TARGET"
+echo "$SEP"
+
+# --- useEffect Anti-Patterns ---
+
+echo ""
+echo "## useEffect setting state from props/state (derived state)"
+echo ""
+rgsearch -n 'useEffect' "$TARGET" -l | while read -r file; do
+  rg -n 'useEffect' "$file" -A 5 2>/dev/null | rg 'set[A-Z]\w*\(' 2>/dev/null | head -20
+done
+echo ""
+
+echo "## useEffect with biome-ignore / eslint-disable for deps"
+echo ""
+rgsearch -n 'biome-ignore.*useExhaustiveDependencies|eslint-disable.*exhaustive-deps' "$TARGET" || echo "(none found)"
+echo ""
+
+echo "## useEffect -> useCallback -> useEffect indirection"
+echo ""
+rgsearch -n 'useEffect' "$TARGET" -l | while read -r file; do
+  rg -n 'useEffect\(' "$file" -A 3 2>/dev/null | rg -o '\[([a-zA-Z_]\w*)\]' 2>/dev/null | tr -d '[]' | sort -u | while read -r dep; do
+    if [ -n "$dep" ] && rg -q "const $dep = useCallback" "$file" 2>/dev/null; then
+      echo "  $file: useEffect depends on useCallback '$dep'"
+    fi
+  done
+done
+echo ""
+
+# --- Cleanup Anti-Patterns ---
+
+echo "## setTimeout without cleanup"
+echo ""
+rgsearch -n 'setTimeout' "$TARGET" | rg -v 'clearTimeout|return.*clear|useEffect|\.test\.|\.spec\.' 2>/dev/null || echo "(none found)"
+echo ""
+
+echo "## setInterval without cleanup"
+echo ""
+rgsearch -n 'setInterval' "$TARGET" | rg -v 'clearInterval|return.*clear' 2>/dev/null || echo "(none found)"
+echo ""
+
+echo "## addEventListener without removeEventListener"
+echo ""
+rgsearch -n 'addEventListener' "$TARGET" | rg -v 'removeEventListener' 2>/dev/null || echo "(none found)"
+echo ""
+
+# --- Navigation Anti-Patterns ---
+
+echo "## window.location.href (should use router navigate)"
+echo ""
+rgsearch -n 'window\.location\.(href|assign|replace)' "$TARGET" || echo "(none found)"
+echo ""
+
+# --- Component Anti-Patterns ---
+
+echo "## Files with multiple .map() callbacks (review for extraction)"
+echo ""
+rgsearch -n '\.map\(\s*\(' "$TARGET" -c | while IFS=: read -r file count; do
+  if [ "$count" -gt 2 ]; then
+    echo "  $file — $count map callbacks"
+  fi
+done
+echo ""
+
+echo "## Inline functions in JSX onClick/onChange (high count per file)"
+echo ""
+rgsearch -n 'on(Click|Change|Submit)=\{?\(\)' "$TARGET" -c | while IFS=: read -r file count; do
+  if [ "$count" -gt 5 ]; then
+    echo "  $file — $count inline handlers"
+  fi
+done
+echo ""
+
+# --- State Anti-Patterns ---
+
+echo "## useState initialized from props (potential mirror state)"
+echo ""
+rgsearch -n 'useState\(\s*(props\.|{.*}|[a-z]+\??\.)' "$TARGET" | head -20
+echo ""
+
+echo "## Clipboard API without error handling"
+echo ""
+rgsearch -n 'navigator\.clipboard' "$TARGET" | rg -v 'try|catch|\.then.*\.catch' 2>/dev/null || echo "(none found)"
+echo ""
+
+echo "$SEP"
+echo "Scan complete. Review flagged files for true positives."


### PR DESCRIPTION
## Summary
- Adds `fixing-react-antipatterns` skill to the `devx-qa` plugin for auditing React codebases and producing scored gap analysis tables
- Includes three reference files (useEffect, component, cleanup patterns) with authoritative rules and before/after fix examples
- Includes a grep-based `scan-antipatterns.sh` script for quick inventory before deep analysis
- Skill follows Anthropic best practices: third-person description, gerund naming, progressive disclosure, concise SKILL.md (88 lines)

## Test plan
- [x] Trigger skill with a path to a React codebase and confirm the 5-step workflow runs (scan → classify → table → fix → lint)
- [x] Confirm reference files are loaded only when needed during classification (Step 2)
- [x] Confirm `scan-antipatterns.sh` runs and flags known anti-patterns in a test React project
- [x] Verify gap analysis table output groups findings by the 5 categories with severity ratings