### PR TITLE
feat(nano-banana-ultimate): image generation plugin with 8 domain-specialized skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -65,6 +65,17 @@
         "repo": "agentic-dev3o/cc-ralph-loop"
       },
       "category": "development"
+    },
+    {
+      "name": "nano-banana-ultimate",
+      "description": "Generate and edit images via Google Gemini with domain-specialized prompt building",
+      "version": "1.0.0",
+      "author": {
+        "name": "Pierre Tomasina",
+        "email": "contact@dev3o.com"
+      },
+      "source": "./plugins/nano-banana-ultimate",
+      "category": "creative"
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -67,6 +67,7 @@ Every command in this marketplace comes from real, daily usage — refined over 
 | [**devx-qa**](plugins/qa/) | Architecture analysis with ASCII diagrams & skill improvement | `/plugin install devx-qa@devx-plugins` |
 | [**secrets-guard**](plugins/secrets-guard/) | Blocks Claude from accessing sensitive files (70+ patterns) | `/plugin install secrets-guard@devx-plugins` |
 | [**landing-page**](plugins/landing-page/) | Structured copywriting & Astro 5 landing page generation | `/plugin install landing-page@devx-plugins` |
+| [**nano-banana-ultimate**](plugins/nano-banana-ultimate/) | Image generation via Gemini with 8 domain-specialized skills | `/plugin install nano-banana-ultimate@devx-plugins` |
 | [**devx-ralph**](#devx-ralph) | Predicate-driven agentic loop for structured implementation | Premium — see below |
 
 ---

--- a/plugins/nano-banana-ultimate/.claude-plugin/plugin.json
+++ b/plugins/nano-banana-ultimate/.claude-plugin/plugin.json
@@ -1,0 +1,9 @@
+{
+  "name": "nano-banana-ultimate",
+  "description": "Generate and edit images via Google Gemini with domain-specialized prompt building for ads, web, YouTube, illustration, logos, people, and objects",
+  "version": "1.0.0",
+  "author": {
+    "name": "Pierre Tomasina",
+    "email": "contact@dev3o.com"
+  }
+}

--- a/plugins/nano-banana-ultimate/README.md
+++ b/plugins/nano-banana-ultimate/README.md
@@ -1,0 +1,88 @@
+# Nano Banana Ultimate
+
+**The best image generation plugin for Claude Code.** Generate and edit images via Google Gemini with domain-specialized auto-prompt building. You describe what you want in plain language — the plugin builds an optimized prompt following [Google's official best practices](https://cloud.google.com/blog/products/ai-machine-learning/ultimate-prompting-guide-for-nano-banana?hl=en).
+
+## Requirements
+
+- [`uv`](https://docs.astral.sh/uv/) installed
+- `GEMINI_API_KEY` environment variable set — [get one here](https://aistudio.google.com/apikey)
+
+## Installation
+
+```
+/plugin install nano-banana-ultimate@devx-plugins
+```
+
+## Skills
+
+| Skill | Trigger | Default Ratio | Description |
+|-------|---------|---------------|-------------|
+| `banana` | "generate image", "edit image", "draw" | 1:1 | General-purpose catch-all for any image |
+| `banana-ads` | "ad", "banner", "social ad" | varies by format | Online advertising visuals with format-aware sizing |
+| `banana-web` | "hero background", "landing page", "web design" | 16:9 | Hero backgrounds, card images, section dividers |
+| `banana-youtube` | "thumbnail", "youtube" | 16:9 | Bold, click-optimized YouTube thumbnails |
+| `banana-illustration` | "illustration", "watercolor", "pixel art" | 1:1 / 4:3 | Flat vector, watercolor, 3D clay, pixel art, isometric |
+| `banana-logo` | "logo", "brand mark", "monogram" | 1:1 | Minimal logo concepts and brand identity marks |
+| `banana-people` | "portrait", "headshot", "lifestyle photo" | 3:4 / 3:2 | Portraits, editorial shots, team photos |
+| `banana-objects` | "product photo", "still life", "food photo" | 1:1 / 4:5 | Product photography, mockups, food shots |
+
+## Quick Start
+
+```
+/banana-youtube coding tutorial about async/await
+```
+
+```
+/banana-logo minimal tech startup called "Nexus" in blue tones
+```
+
+```
+/banana-ads Instagram story ad for a meditation app
+```
+
+Or just say what you want — Claude routes to the right skill automatically.
+
+## Models
+
+| Model | Name | Speed | Quality | Best For |
+|-------|------|-------|---------|----------|
+| `gemini-3-pro-image-preview` | Nano Banana Pro | Slower | Highest | Final output, complex scenes |
+| `gemini-3.1-flash-image-preview` | Nano Banana 2 | Fast | Good | Drafts, iterations, simple images |
+
+Default: **Nano Banana Pro** for maximum quality.
+
+## Features
+
+- **Auto-prompt building** — You say "a product photo of headphones", Claude builds a detailed prompt with lighting, camera specs, composition, and materiality
+- **8 domain-specialized skills** — Each skill applies domain-specific defaults (aspect ratio, resolution, lighting style, composition rules)
+- **Image editing** — Pass existing images with `--input-image` for background swaps, style transfers, and refinements (up to 14 reference images)
+- **Google best practices** — Every prompt uses positive framing, strong verb openers, camera/lens specs, and materiality descriptions
+- **63 reference prompts** — Curated examples across all domains for inspiration and consistency
+- **Resolution control** — 1K for drafts, 2K for production, 4K for print
+- **10 aspect ratios** — From 1:1 squares to 21:9 ultrawide banners
+
+## How It Works
+
+1. You describe what you want in plain language
+2. Claude identifies the domain and applies the right skill
+3. The skill builds an optimized Gemini prompt using the formula: `[Subject] + [Action] + [Location] + [Composition] + [Style]`
+4. A Python script calls the Google Gemini API and saves a PNG
+5. Claude reports the file path and offers to iterate
+
+## File Structure
+
+```
+nano-banana-ultimate/
+├── .claude-plugin/plugin.json        # Plugin manifest
+├── scripts/banana.py                 # Single Python script (google-genai + Pillow)
+├── skills/
+│   ├── banana/                       # General-purpose catch-all
+│   ├── banana-ads/                   # Online advertising
+│   ├── banana-web/                   # Web design assets
+│   ├── banana-youtube/               # YouTube thumbnails
+│   ├── banana-illustration/          # Illustrations (7 sub-styles)
+│   ├── banana-logo/                  # Logos and brand identity
+│   ├── banana-people/                # People and portraits
+│   └── banana-objects/               # Products and objects
+└── README.md
+```

--- a/plugins/nano-banana-ultimate/scripts/banana.py
+++ b/plugins/nano-banana-ultimate/scripts/banana.py
@@ -1,0 +1,141 @@
+#!/usr/bin/env python3
+# /// script
+# requires-python = ">=3.10"
+# dependencies = [
+#     "google-genai>=1.0.0",
+#     "pillow>=10.0.0",
+# ]
+# ///
+"""Nano Banana Ultimate — Image generation and editing via Google Gemini."""
+
+import argparse
+import os
+import sys
+
+ASPECT_RATIOS = [
+    "1:1", "3:2", "2:3", "4:3", "3:4",
+    "16:9", "9:16", "4:5", "5:4", "21:9",
+]
+
+MODELS = [
+    "gemini-3-pro-image-preview",
+    "gemini-3.1-flash-image-preview",
+]
+
+RESOLUTIONS = ["1K", "2K", "4K"]
+
+
+def parse_args():
+    parser = argparse.ArgumentParser(description="Generate or edit images via Google Gemini")
+    parser.add_argument("-p", "--prompt", required=True, help="Image description or edit instruction")
+    parser.add_argument("-o", "--output", required=True, help="Output file path (.png)")
+    parser.add_argument("-i", "--input-image", action="append", default=[], help="Input image path (repeatable, up to 14)")
+    parser.add_argument("-r", "--resolution", choices=RESOLUTIONS, default=None, help="Output resolution (default: 1K)")
+    parser.add_argument("-a", "--aspect-ratio", choices=ASPECT_RATIOS, default="1:1", help="Aspect ratio (default: 1:1)")
+    parser.add_argument("-m", "--model", choices=MODELS, default="gemini-3-pro-image-preview", help="Gemini model to use")
+    return parser.parse_args()
+
+
+def detect_resolution(images):
+    """Auto-detect resolution from input image dimensions."""
+    max_dim = 0
+    for img in images:
+        max_dim = max(max_dim, img.width, img.height)
+    if max_dim <= 1500:
+        return "1K"
+    elif max_dim <= 3000:
+        return "2K"
+    return "4K"
+
+
+def load_input_images(paths):
+    """Load and validate input images."""
+    from PIL import Image
+
+    if len(paths) > 14:
+        print("Error: Maximum 14 input images allowed.", file=sys.stderr)
+        sys.exit(1)
+
+    images = []
+    for path in paths:
+        if not os.path.isfile(path):
+            print(f"Error: Input image not found: {path}", file=sys.stderr)
+            sys.exit(1)
+        images.append(Image.open(path))
+    return images
+
+
+def save_image(image, output_path):
+    """Save image as PNG, handling RGBA to RGB conversion."""
+    from PIL import Image
+
+    if image.mode == "RGBA":
+        background = Image.new("RGB", image.size, (255, 255, 255))
+        background.paste(image, mask=image.split()[3])
+        image = background
+    elif image.mode != "RGB":
+        image = image.convert("RGB")
+
+    os.makedirs(os.path.dirname(output_path) or ".", exist_ok=True)
+    image.save(output_path, format="PNG")
+
+
+def generate(args):
+    """Run image generation or editing."""
+    api_key = os.environ.get("GEMINI_API_KEY")
+    if not api_key:
+        print("Error: GEMINI_API_KEY environment variable is not set.", file=sys.stderr)
+        print("Get a key at https://aistudio.google.com/apikey", file=sys.stderr)
+        sys.exit(1)
+
+    from google import genai
+    from google.genai import types
+
+    client = genai.Client(api_key=api_key)
+
+    input_images = load_input_images(args.input_image) if args.input_image else []
+
+    resolution = args.resolution
+    if not resolution:
+        resolution = detect_resolution(input_images) if input_images else "1K"
+
+    if input_images:
+        contents = input_images + [args.prompt]
+    else:
+        contents = [args.prompt]
+
+    response = client.models.generate_content(
+        model=args.model,
+        contents=contents,
+        config=types.GenerateContentConfig(
+            response_modalities=["TEXT", "IMAGE"],
+            image_config=types.ImageConfig(
+                aspect_ratio=args.aspect_ratio,
+                image_size=resolution,
+            ),
+        ),
+    )
+
+    from PIL import Image
+    import io
+
+    saved = False
+    for part in response.parts:
+        if hasattr(part, "inline_data") and part.inline_data:
+            image_bytes = part.inline_data.data
+            pil_image = Image.open(io.BytesIO(image_bytes))
+            save_image(pil_image, args.output)
+            saved = True
+            print(args.output)
+            break
+        elif hasattr(part, "text") and part.text:
+            print(part.text, file=sys.stderr)
+
+    if not saved:
+        print("Error: No image was generated. The model returned only text.", file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    args = parse_args()
+    generate(args)

--- a/plugins/nano-banana-ultimate/skills/banana-ads/SKILL.md
+++ b/plugins/nano-banana-ultimate/skills/banana-ads/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: banana-ads
+description: >-
+  Generate advertising visuals — banners, social media ads, display ads, and
+  promotional graphics with auto-prompt building and format-aware aspect ratios.
+  Triggers on: ad, banner, advertisement, display ad, social ad, promo graphic,
+  campaign visual, marketing image, sponsored post image, ad creative.
+allowed-tools: Bash(uv:*), Bash(ls:*), Read
+---
+
+# Online Advertising Visuals
+
+**Input:** `$ARGUMENTS` (optional — product/service and ad format)
+
+If `$ARGUMENTS` is provided, use it as the campaign brief and skip to prompt building. If empty, ask about the product and target placement.
+
+## Requirements
+
+- `uv` installed
+- `GEMINI_API_KEY` environment variable set (get one at https://aistudio.google.com/apikey)
+
+## Workflow
+
+1. **Understand** — Clarify the product or service, the value proposition, and the target ad placement (Instagram feed, YouTube pre-roll, web banner, etc.).
+2. **Build prompt** — Apply the Prompt Formula below to construct a bold, commercially viable image description.
+3. **Configure** — Detect the ad format from context and select aspect ratio and resolution from the Ad Format Detection table.
+4. **Generate** — Run the script. the generation script with the assembled prompt and settings.
+5. **Deliver** — Report the saved file path. Do NOT read the image file back. Offer to iterate: adjust composition, color palette, or layout.
+
+## Prompt Formula
+
+```
+[Product/Service] + [Value Proposition as Action] + [Ad Placement Context] + [Bold Center-Weighted Composition] + [Clean Commercial Photography or Flat Design]
+```
+
+## Ad Format Detection
+
+| Placement              | Aspect Ratio | Resolution |
+|------------------------|--------------|------------|
+| Instagram/Facebook feed | 4:5          | 2K         |
+| Instagram story         | 9:16         | 2K         |
+| YouTube pre-roll        | 16:9         | 2K         |
+| Web banner              | 21:9         | 2K         |
+| Square social           | 1:1          | 2K         |
+
+## Key Instructions
+
+- **Negative space for text overlay** -- Always leave generous negative space (top, bottom, or side) for headline and CTA placement. Ad visuals are incomplete without copy; design the composition to accommodate it.
+- **No baked-in text** -- Do NOT prompt Gemini to render text into the image. Gemini text rendering is unreliable and produces artifacts. Advise the user to add headlines, CTAs, and legal copy in a separate design tool (Figma, Canva, Photoshop).
+- **Bold center-weighted composition** -- Place the hero product or key visual element at the center or slightly off-center with clean breathing room around it.
+- **Commercial lighting** -- Default to clean, bright studio lighting with soft shadows. Use high-key lighting for upbeat campaigns and moody side lighting for premium or luxury positioning.
+- **Color psychology** -- Match the color palette to the campaign intent: warm tones for urgency and sales, cool tones for trust and tech, vibrant saturated hues for youth and energy.
+
+## Generation
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/scripts/banana.py" \
+  --prompt "<detailed prompt following the formula>" \
+  --output "<YYYY-MM-DD-HH-MM-SS-descriptive-name>.png" \
+  --resolution <2K> \
+  --aspect-ratio <ratio from Ad Format Detection table> \
+  --model gemini-3-pro-image-preview
+```
+
+## Editing (with input images)
+
+When the user provides a product photo or existing visual to modify:
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/scripts/banana.py" \
+  --prompt "<edit instruction: what to change AND what to keep>" \
+  --output "<YYYY-MM-DD-HH-MM-SS-descriptive-name>.png" \
+  --input-image "/path/to/source.png" \
+  --aspect-ratio <ratio>
+```
+
+For edits, describe both the change and what must stay identical:
+> "Place this product on a clean bright studio background with soft shadow. Keep the product, its color, and proportions exactly the same."
+
+Up to 14 input images can be passed (repeat `--input-image` for each).
+
+## References
+
+See [references/prompts.md](references/prompts.md) for ready-to-use example prompts covering common advertising visual scenarios.

--- a/plugins/nano-banana-ultimate/skills/banana-ads/references/prompts.md
+++ b/plugins/nano-banana-ultimate/skills/banana-ads/references/prompts.md
@@ -1,0 +1,33 @@
+# Advertising Visual Prompts
+
+## 1. Social Square Ad
+**Use case:** Product-focused social media post | **Aspect ratio:** 1:1 | **Resolution:** 2K
+> Photograph a premium wireless earbud resting on a polished obsidian slab, soft studio lighting with a gentle highlight bloom on the left ear tip, clean white background with ample negative space on the top third for headline placement. Bold center-weighted composition, clean commercial photography with controlled reflections.
+
+## 2. Instagram Story Ad
+**Use case:** Vertical swipe-up promotion for a mobile app | **Aspect ratio:** 9:16 | **Resolution:** 2K
+> Capture a hand holding a smartphone displaying a vibrant fitness dashboard, shot from a slight low angle against a gradient sky transitioning from coral to deep violet. The upper and lower thirds are left as open negative space for CTA text. Clean commercial photography, bright natural lighting with soft edge glow.
+
+## 3. YouTube Pre-Roll Frame
+**Use case:** Opening frame for a video ad campaign | **Aspect ratio:** 16:9 | **Resolution:** 2K
+> Capture a sleek electric sedan driving along a coastal highway at golden hour, motion blur on the road surface conveying speed, the car positioned in the right third of the frame. The left side opens into a clean sky gradient with generous negative space for brand messaging. Cinematic commercial photography, warm directional sunlight with lens flare.
+
+## 4. Web Banner Strip
+**Use case:** Horizontal leaderboard banner for website header | **Aspect ratio:** 21:9 | **Resolution:** 2K
+> Compose a flat-lay arrangement of artisanal coffee beans, a ceramic pour-over dripper, and a linen napkin spread across a reclaimed oak surface, shot from directly above. The right two-thirds are deliberately sparse, leaving clean negative space for promotional copy. Soft diffused overhead lighting, clean commercial photography with muted earth tones.
+
+## 5. Facebook Feed Ad
+**Use case:** Scroll-stopping feed placement for a subscription service | **Aspect ratio:** 4:5 | **Resolution:** 2K
+> Arrange three stacked meal-prep containers with colorful, freshly prepared dishes — grilled salmon, roasted vegetables, and quinoa — arranged in a diagonal cascade on a white marble countertop. The top quarter is left open with soft ambient light for headline overlay. Bright high-key commercial photography, clean shadows, and vivid food color saturation.
+
+## 6. Product Launch Visual
+**Use case:** Hero image for a new product announcement | **Aspect ratio:** 1:1 | **Resolution:** 2K
+> Render a matte black smartwatch floating against a deep navy gradient background, a single dramatic side light casting a crisp highlight along the bezel edge and a soft shadow underneath. The lower third is open negative space for launch date and tagline placement. Bold center-weighted composition, premium studio photography with controlled specular reflections.
+
+## 7. Seasonal Sale Graphic
+**Use case:** Limited-time promotion for an e-commerce store | **Aspect ratio:** 4:5 | **Resolution:** 2K
+> Compose a curated stack of folded cashmere sweaters in warm autumn tones — burnt sienna, mustard, and cream — placed on a raw wooden shelf with a single dried eucalyptus branch beside them. The upper third fades into a soft blurred background providing clean negative space for sale messaging. Warm directional lighting from the left, clean commercial photography with cozy seasonal atmosphere.
+
+## 8. App Download Promo
+**Use case:** Mobile app install campaign across social platforms | **Aspect ratio:** 9:16 | **Resolution:** 2K
+> Photograph a smartphone standing upright on a glossy white surface displaying a meditation app interface with a calming gradient screen, surrounded by smooth river stones and a single green succulent. Soft top-down studio lighting with gentle reflections on the surface. The top and bottom quarters are clean negative space for app store badges and headline text. Minimal flat design aesthetic, bright and airy commercial composition.

--- a/plugins/nano-banana-ultimate/skills/banana-illustration/SKILL.md
+++ b/plugins/nano-banana-ultimate/skills/banana-illustration/SKILL.md
@@ -1,0 +1,85 @@
+---
+name: banana-illustration
+description: >-
+  Generate illustrations in various styles — flat vector, watercolor, line art,
+  3D clay render, pixel art, and isometric. Auto-detects style from context.
+  Triggers on: illustration, illustrate, flat design, watercolor, line art,
+  pixel art, 3D illustration, isometric, sketch, cartoon, vector art, hand drawn.
+allowed-tools: Bash(uv:*), Bash(ls:*), Read
+---
+
+# Illustration Generator
+
+**Input:** `$ARGUMENTS` (optional — subject and style description)
+
+If `$ARGUMENTS` is provided, use it as the illustration brief and skip to prompt building. If empty, ask about subject and style.
+
+## Requirements
+
+- `uv` installed
+- `GEMINI_API_KEY` environment variable set (get one at https://aistudio.google.com/apikey)
+
+## Workflow
+
+1. **Understand** — Parse the user's request. Identify the subject, narrative action, environment, and desired art style. If the style is ambiguous, ask ONE clarifying question or default to flat vector.
+2. **Build prompt** — Apply the Prompt Formula below to construct a detailed, positive-framed illustration description.
+3. **Configure** — Select aspect ratio and resolution from the Domain Defaults table.
+4. **Generate** — Run the script.
+5. **Deliver** — Report the saved file path. Do NOT read the image file back. Offer to iterate: swap style, adjust palette, or tweak composition.
+
+## Prompt Formula
+
+```
+[Subject/Character] + [Narrative Action] + [Illustrated Environment] + [Balanced Composition] + [Explicit Art Style]
+```
+
+## Style Detection Rules
+
+| User Keywords              | Resolved Style                                                    |
+|----------------------------|-------------------------------------------------------------------|
+| "flat" / "vector"          | Flat vector with solid fills, clean edges                         |
+| "watercolor"               | Wet-on-wet watercolor with paper texture, visible brushstrokes    |
+| "3D" / "clay"              | Pixar-style clay render, soft shadows                             |
+| "pixel"                    | Pixel art with visible grid, limited palette                      |
+| "isometric"                | Isometric projection, no perspective vanishing points             |
+| "line art" / "ink"         | Consistent weight ink lines, minimal fills                        |
+| Ambiguous                  | Default to flat vector                                            |
+
+## Domain Defaults
+
+| Domain         | Aspect Ratio | Resolution |
+|----------------|--------------|------------|
+| Spot / Icon    | 1:1          | 1K         |
+| Scene          | 4:3          | 1K         |
+
+## Generation
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/scripts/banana.py" \
+  --prompt "<detailed prompt following the formula>" \
+  --output "<YYYY-MM-DD-HH-MM-SS-descriptive-name>.png" \
+  --resolution 1K \
+  --aspect-ratio <ratio from Domain Defaults> \
+  --model gemini-3-pro-image-preview
+```
+
+## Editing (with input images)
+
+When the user provides an existing image to restyle or modify:
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/scripts/banana.py" \
+  --prompt "<edit instruction: what to change AND what to keep>" \
+  --output "<YYYY-MM-DD-HH-MM-SS-descriptive-name>.png" \
+  --input-image "/path/to/source.png" \
+  --aspect-ratio <ratio>
+```
+
+For style transfers, describe the target style and what to preserve:
+> "Recreate this photograph as a flat vector illustration with a limited palette of teal, coral, and cream. Keep the composition, subject pose, and environment layout exactly the same."
+
+Up to 14 input images can be passed (repeat `--input-image` for each).
+
+## References
+
+See [references/prompts.md](references/prompts.md) for ready-to-use example prompts covering common illustration styles and scenarios.

--- a/plugins/nano-banana-ultimate/skills/banana-illustration/references/prompts.md
+++ b/plugins/nano-banana-ultimate/skills/banana-illustration/references/prompts.md
@@ -1,0 +1,49 @@
+# Illustration -- Example Prompts
+
+## 1. Flat Vector Icon
+
+**Use case:** App icon or UI spot illustration | **Aspect ratio:** 1:1 | **Resolution:** 1K
+
+> Render a single ripe banana with a cheerful face, rendered in flat vector style with solid color fills and clean hard edges. Bright yellow body with a warm brown stem, set against a soft mint-green circle background. Minimal shading using two-tone flat color blocks, center-weighted composition with generous padding around the subject.
+
+## 2. Watercolor Landscape
+
+**Use case:** Editorial header or greeting card artwork | **Aspect ratio:** 4:3 | **Resolution:** 1K
+
+> Paint a misty mountain valley at dawn painted in wet-on-wet watercolor technique, with visible paper grain texture and soft pigment bleeds where the indigo sky meets the emerald tree line. Pale apricot and lavender washes in the sky transition into deep viridian forest tones. Loose brushstrokes define pine silhouettes in the foreground while the distant peaks dissolve into atmospheric haze.
+
+## 3. Ink Line Art Portrait
+
+**Use case:** Author bio illustration or zine artwork | **Aspect ratio:** 1:1 | **Resolution:** 1K
+
+> Draw a three-quarter view portrait of a person in their 30s with curly shoulder-length hair, drawn in consistent-weight black ink lines on white background. Minimal crosshatching for shadow under the jawline and around the eyes, with no color fills. Fine detail in the hair strands and fabric folds of a collared shirt, composed with the face offset slightly right following the rule of thirds.
+
+## 4. 3D Clay Character
+
+**Use case:** Mascot design or onboarding illustration | **Aspect ratio:** 1:1 | **Resolution:** 1K
+
+> Model a friendly robot character in Pixar-style clay render with smooth rounded limbs, a dome-shaped head, and oversized expressive eyes. Soft pastel blue body with matte finish, warm orange accent buttons on the chest, and subtle ambient occlusion in the joints. Soft directional lighting from the upper left casts gentle shadows on a seamless light-grey studio backdrop.
+
+## 5. Pixel Art Game Sprite
+
+**Use case:** Retro game asset or nostalgic social media graphic | **Aspect ratio:** 1:1 | **Resolution:** 1K
+
+> Create a 32x32 pixel art knight character in mid-stride, holding a small shield and sword, rendered with a visible pixel grid and a limited 16-color palette. Steel-grey armor with cobalt-blue cape, warm skin tones, and a single-pixel highlight on the helmet visor. Black outline around the full character, transparent background, classic side-scrolling adventure pose.
+
+## 6. Isometric Room
+
+**Use case:** Explainer graphic or portfolio piece | **Aspect ratio:** 4:3 | **Resolution:** 1K
+
+> Render an isometric cutaway view of a cozy home office, rendered in strict isometric projection with no perspective vanishing points. A wooden desk holds a monitor, succulent plant, and coffee mug; a bookshelf lines the back wall; a round rug sits on the hardwood floor. Clean vector lines with soft flat-color shading, muted earth-tone palette of warm oak, sage green, and cream white, with each object aligned to the isometric grid.
+
+## 7. Hand-Drawn Botanical
+
+**Use case:** Product label or stationery design | **Aspect ratio:** 4:3 | **Resolution:** 1K
+
+> Sketch a hand-drawn botanical study of a monstera deliciosa leaf and stem, sketched with loose graphite pencil lines and subtle sage-green watercolor wash fills. Visible pencil texture and slight imperfections give an authentic sketchbook feel. Delicate vein details traced in fine 0.3mm pen, with the leaf positioned off-center on a cream paper background, leaving open space for text placement on the right third.
+
+## 8. Children's Book Scene
+
+**Use case:** Picture book spread or nursery wall art | **Aspect ratio:** 4:3 | **Resolution:** 1K
+
+> Illustrate a whimsical nighttime forest scene in a warm children's book illustration style, featuring a small fox cub sitting on a mossy log and gazing up at a sky full of oversized glowing stars. Rounded, friendly shapes with soft outlines, a rich palette of deep teal, warm amber, and dusty violet. Layered background with silhouetted trees receding into gentle fog, fireflies dotting the mid-ground with tiny golden highlights.

--- a/plugins/nano-banana-ultimate/skills/banana-logo/SKILL.md
+++ b/plugins/nano-banana-ultimate/skills/banana-logo/SKILL.md
@@ -1,0 +1,94 @@
+---
+name: banana-logo
+description: >-
+  Generate logo concepts and brand identity marks — abstract marks, lettermarks,
+  mascot emblems, and geometric icons with minimal clean aesthetics.
+  Triggers on: logo, brand mark, wordmark, lettermark, icon logo, brand identity,
+  monogram, emblem, logo design, logo concept.
+allowed-tools: Bash(uv:*), Bash(ls:*), Read
+---
+
+# Logo & Brand Identity
+
+**Input:** `$ARGUMENTS` (optional — brand name, industry, and style direction)
+
+If `$ARGUMENTS` is provided, use it as the brand brief and skip to prompt building. If empty, ask about the brand.
+
+## Requirements
+
+- `uv` installed
+- `GEMINI_API_KEY` environment variable set (get one at https://aistudio.google.com/apikey)
+
+## Workflow
+
+1. **Understand** — Clarify the brand name, industry, personality adjectives (e.g., bold, playful, minimal), and any existing color palette or symbol preferences the user has.
+2. **Build prompt** — Compose a generation prompt following the Prompt Formula below, incorporating the user's brand attributes.
+3. **Configure** — Apply the Defaults (1:1, 1K, Pro model). Override only if the user explicitly requests a different setting.
+4. **Generate** — Run the script.
+5. **Deliver** — Report the saved file path. Do NOT read the image file back. Remind the user of the Text Caveat if letterforms are included. Offer to iterate.
+
+## Prompt Formula
+
+```
+[Brand Symbol/Shape] + [Static Balanced Pose] + [White Background] + [Centered Symmetric Composition] + [Minimal Flat Vector / Geometric]
+```
+
+## Defaults
+
+ALWAYS apply these unless the user explicitly overrides:
+
+| Setting | Value |
+|---------|-------|
+| Aspect ratio | 1:1 |
+| Resolution | 1K |
+| Model | Pro |
+
+## Key Constraints
+
+- **Favicon test** -- The logo must work at 16x16 px favicon size. Avoid fine details, thin strokes, and intricate ornamentation.
+- **Color limit** -- Maximum 2-3 colors. Fewer colors reproduce better across media.
+- **White background** -- Always include "on a white background" in the prompt for easy extraction and compositing.
+- **Shape language** -- Angular shapes convey tech / aggressive energy. Rounded shapes convey friendly / approachable energy. Choose deliberately.
+- **TEXT CAVEAT** -- Gemini is unreliable for exact letterforms. Warn the user: treat any text in the generated image as a visual concept only and recreate it in a proper vector tool (Figma, Illustrator, Inkscape) for final use.
+
+## Logo Type Guidance
+
+| Type | When to use | Prompt emphasis |
+|------|------------|-----------------|
+| **Abstract mark** | Brand wants a unique symbol not tied to a literal object | Geometric shapes, overlapping forms, negative space |
+| **Lettermark** | Brand name is long or acronym-friendly | Bold single letter or monogram, simple sans-serif geometry |
+| **Mascot** | Brand targets a playful or community-driven audience | Simplified character, minimal detail, bold outline |
+| **Geometric icon** | App icon or tech product needing a clean scalable mark | Primitive shapes (circle, square, triangle), flat color fills |
+
+## Generation
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/scripts/banana.py" \
+  --prompt "<detailed prompt following the formula>" \
+  --output "<YYYY-MM-DD-HH-MM-SS-descriptive-name>.png" \
+  --resolution 1K \
+  --aspect-ratio 1:1 \
+  --model gemini-3-pro-image-preview
+```
+
+## Editing (with input images)
+
+When the user provides an existing logo or sketch to refine:
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/scripts/banana.py" \
+  --prompt "<edit instruction: what to change AND what to keep>" \
+  --output "<YYYY-MM-DD-HH-MM-SS-descriptive-name>.png" \
+  --input-image "/path/to/source.png" \
+  --resolution 1K \
+  --aspect-ratio 1:1
+```
+
+For logo refinements, be explicit about what to preserve:
+> "Simplify this sketch into a clean geometric vector mark using only two colors: deep navy and white. Keep the overall shape and proportions exactly the same."
+
+Up to 14 input images can be passed (repeat `--input-image` for each).
+
+## References
+
+See [references/prompts.md](references/prompts.md) for ready-to-use example prompts.

--- a/plugins/nano-banana-ultimate/skills/banana-logo/references/prompts.md
+++ b/plugins/nano-banana-ultimate/skills/banana-logo/references/prompts.md
@@ -1,0 +1,25 @@
+# Logo Prompt Examples
+
+## 1. Abstract Tech Mark
+**Use case:** SaaS or developer-tool brand needing a distinctive symbol | **Aspect ratio:** 1:1 | **Resolution:** 1K
+> Design a minimal abstract logo composed of two overlapping geometric shapes forming a subtle forward arrow, using only deep indigo and electric teal on a white background. Flat vector style, perfectly centered and symmetrical, no gradients, no text. Must read clearly at 16x16 px.
+
+## 2. Lettermark Monogram
+**Use case:** Startup with a long name that abbreviates to two letters | **Aspect ratio:** 1:1 | **Resolution:** 1K
+> Create a bold monogram logo of the letters "NB" constructed from thick geometric sans-serif strokes, interlocked in a square frame. Two colors only: charcoal black and bright coral on a white background. Flat vector, centered composition, no decorative detail. Designed to remain legible at favicon size.
+
+## 3. Mascot Emblem
+**Use case:** Community platform or gaming brand wanting a friendly character mark | **Aspect ratio:** 1:1 | **Resolution:** 1K
+> Design a simplified mascot logo of a stylized owl face built from basic circles and triangles, using warm orange and dark slate gray on a white background. Flat geometric vector style, perfectly symmetrical, bold outlines, no fine detail. The shape should be instantly recognizable at very small sizes.
+
+## 4. Minimal Wordmark
+**Use case:** Clean consumer brand where the name itself is the logo | **Aspect ratio:** 1:1 | **Resolution:** 1K
+> Create a minimal wordmark logo spelling "Bloom" in a custom rounded geometric sans-serif typeface, single weight, black on a white background. Centered, balanced letter spacing, no icon, no decoration. The letterforms use soft rounded terminals for a friendly approachable feel. Keep it simple enough to work at 16x16 px.
+
+## 5. Geometric App Icon
+**Use case:** Mobile app or web product needing a scalable square icon | **Aspect ratio:** 1:1 | **Resolution:** 1K
+> Design a geometric app icon logo consisting of a single rounded square containing a concentric circle and dot at its center, using only vibrant violet and white. Flat vector, perfectly centered, no gradients or shadows. The design is reduced to primitive shapes so it remains crisp and identifiable at the smallest display sizes.
+
+## 6. Nature-Inspired Brand Mark
+**Use case:** Sustainability or wellness brand seeking an organic yet modern symbol | **Aspect ratio:** 1:1 | **Resolution:** 1K
+> Create a nature-inspired logo of a single stylized leaf constructed from two overlapping ellipses, rendered in forest green and soft lime on a white background. Flat geometric vector, symmetrical, centered composition, no texture or fine veining. The shape is bold and simple enough to function as a favicon without losing its identity.

--- a/plugins/nano-banana-ultimate/skills/banana-objects/SKILL.md
+++ b/plugins/nano-banana-ultimate/skills/banana-objects/SKILL.md
@@ -1,0 +1,84 @@
+---
+name: banana-objects
+description: >-
+  Generate product photography and object images — product shots, still life,
+  packaging mockups, food photography, and item compositions with studio lighting.
+  Triggers on: product photo, product shot, still life, object, packaging,
+  food photo, mockup, e-commerce photo, item photography.
+allowed-tools: Bash(uv:*), Bash(ls:*), Read
+---
+
+# Object & Product Photography
+
+**Input:** `$ARGUMENTS` (optional — product description and intended use)
+
+If `$ARGUMENTS` is provided, use it as the product brief and skip to prompt building. If empty, ask about the product and context.
+
+## Requirements
+
+- `uv` installed
+- `GEMINI_API_KEY` environment variable set (get one at https://aistudio.google.com/apikey)
+
+## Workflow
+
+1. **Understand** — Clarify the product, surface, and intended use (catalog, social, editorial).
+2. **Build prompt** — Apply the Prompt Formula below to construct a detailed, positive-framed image description.
+3. **Configure** — Select aspect ratio and resolution from the Domain Defaults table.
+4. **Generate** — Run the script.
+5. **Deliver** — Report the saved file path. Do NOT read the image file back. Offer to iterate: adjust angle, lighting, or surface.
+
+## Prompt Formula
+
+```
+[Object with Material Description] + [Resting/Floating on Surface] + [Studio or Lifestyle Setting] + [Center-Weighted Hero Composition] + [Studio Photography, Controlled Lighting]
+```
+
+## Domain Defaults
+
+| Domain              | Aspect Ratio | Resolution |
+|---------------------|--------------|------------|
+| E-commerce catalog  | 1:1          | 2K         |
+| Instagram product   | 4:5          | 2K         |
+| Lifestyle context   | 4:3          | 2K         |
+
+**Lighting guidance:** Use soft diffused studio lighting as the default. Switch to backlit setups for glass and translucent materials to emphasize clarity and refraction.
+
+## Key Instructions
+
+- **Material properties** -- Always describe the material explicitly: matte aluminum, glossy ceramic, brushed steel, frosted glass, soft-touch rubber. Material language drives realism.
+- **Surface specification** -- State the surface the object rests on: marble slab, reclaimed wooden table, white sweep, linen cloth, terrazzo countertop.
+- **Food photography** -- Include sensory texture cues: rising steam, a drip of honey mid-fall, glistening condensation, crispy golden edges, powdered sugar dusting.
+- **Sense of scale** -- Place a contextual element nearby (a hand, a coin, a coffee cup) or describe relative size so the viewer anchors the object's dimensions.
+
+## Generation
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/scripts/banana.py" \
+  --prompt "<detailed prompt following the formula>" \
+  --output "<YYYY-MM-DD-HH-MM-SS-descriptive-name>.png" \
+  --resolution 2K \
+  --aspect-ratio <ratio from Domain Defaults> \
+  --model gemini-3-pro-image-preview
+```
+
+## Editing (with input images)
+
+When the user provides an existing product photo to modify (e.g., change background, adjust lighting, add props):
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/scripts/banana.py" \
+  --prompt "<edit instruction: what to change AND what to keep>" \
+  --output "<YYYY-MM-DD-HH-MM-SS-descriptive-name>.png" \
+  --input-image "/path/to/source.png" \
+  --resolution 2K \
+  --aspect-ratio <ratio>
+```
+
+For edits, describe both the change and what must stay identical:
+> "Replace the white background with a lifestyle scene on a rustic wooden table with warm morning light. Keep the product, its label, color, and proportions exactly the same."
+
+Up to 14 input images can be passed (repeat `--input-image` for each).
+
+## References
+
+See [references/prompts.md](references/prompts.md) for ready-to-use example prompts covering common product photography scenarios.

--- a/plugins/nano-banana-ultimate/skills/banana-objects/references/prompts.md
+++ b/plugins/nano-banana-ultimate/skills/banana-objects/references/prompts.md
@@ -1,0 +1,57 @@
+# Object & Product Photography -- Example Prompts
+
+## 1. White-Sweep Product Shot
+
+**Use case:** Minimalist beauty product for e-commerce catalog or brand website hero image.
+**Aspect ratio:** 1:1 | **Resolution:** 2K
+
+> Capture a frosted-glass serum bottle with a brushed gold dropper cap, standing upright on an infinite white sweep. Soft diffused studio lighting from a large overhead softbox wraps evenly around the bottle, casting a subtle contact shadow. Shot with a Canon EOS R5, 100mm macro lens at f/8, capturing every etched logo detail and the translucent amber liquid inside.
+
+## 2. Lifestyle Context
+
+**Use case:** Social media or blog imagery showing a product in an everyday setting.
+**Aspect ratio:** 4:3 | **Resolution:** 2K
+
+> Photograph a handmade speckled ceramic coffee mug filled with steaming oat-milk latte, resting on a weathered oak desk beside an open leather-bound notebook and a brass pen. Warm morning window light spills across the scene from the left, creating long soft shadows. Captured with a Sony A7 IV, 35mm f/1.4 lens at f/2.8, shallow depth of field blurring the notebook into a creamy bokeh.
+
+## 3. Food Flat Lay
+
+**Use case:** Overhead brunch spread for food magazine editorial or restaurant social feed.
+**Aspect ratio:** 1:1 | **Resolution:** 2K
+
+> Compose a top-down flat lay of a weekend brunch spread on a white marble countertop: golden sourdough toast with melting butter, a halved avocado with visible seed pit, a small bowl of granola with fresh blueberries, and a glass of freshly squeezed orange juice with pulp. Even overhead studio lighting eliminates harsh shadows, and each item is arranged in a balanced grid composition. Shot with a Nikon Z8, 50mm f/1.8 at f/5.6, emphasizing crispy bread texture and glistening fruit.
+
+## 4. Drink with Condensation
+
+**Use case:** Cold beverage studio shot for advertising, menu board, or packaging label.
+**Aspect ratio:** 4:5 | **Resolution:** 2K
+
+> Photograph a tall slender glass bottle of sparkling lemonade, beaded with heavy condensation droplets rolling down its surface, placed on a wet slate coaster. A sprig of fresh mint and a lemon wheel lean against the base. Dramatic side lighting from a single strip softbox highlights every water droplet against a deep charcoal background. Photographed with a Phase One IQ4, 120mm macro at f/11, freezing each droplet in tack-sharp detail.
+
+## 5. Packaging Mockup
+
+**Use case:** Subscription box unboxing scene for e-commerce landing page or crowdfunding campaign.
+**Aspect ratio:** 4:3 | **Resolution:** 2K
+
+> Compose an open kraft-paper subscription box with its lid leaning against the side, revealing neatly arranged items inside: a small amber glass candle, a linen pouch, and a wrapped chocolate bar with gold foil. The box sits on a clean white linen surface with tissue paper artfully spilling over the edge. Soft overhead strip lighting with a slight warm tone creates an inviting unboxing atmosphere. Shot with a Canon EOS R6, 24-70mm f/2.8 at 50mm and f/4, balanced center-weighted composition.
+
+## 6. Jewelry Close-Up
+
+**Use case:** Fine jewelry detail shot for luxury e-commerce or engagement campaign.
+**Aspect ratio:** 4:5 | **Resolution:** 2K
+
+> Capture a polished platinum engagement ring with a brilliant-cut diamond, resting on a honed Calacatta marble slab. A single focused spotlight from the upper right creates a dramatic specular highlight on the diamond's crown facets while the platinum band gleams with soft reflected light. The background falls to pure black. Shot with a Hasselblad X2D, 90mm macro at f/16, extreme close-up revealing every facet and micro-engraving on the inner band.
+
+## 7. Tech Gadget
+
+**Use case:** Wireless earbuds hero image for product launch page or tech review site.
+**Aspect ratio:** 1:1 | **Resolution:** 2K
+
+> Render a pair of matte-white wireless earbuds floating mid-air above their open glossy charging case, captured in a gravity-defying arrangement against a gradient background shifting from soft grey to white. Two opposing softboxes produce clean, even lighting that accentuates the smooth polycarbonate shell and the metallic mesh of each speaker grille. Shot with a Sony A1, 90mm macro at f/8, perfectly symmetrical composition with razor-sharp focus across both buds.
+
+## 8. Skincare Line
+
+**Use case:** Product trio arrangement for brand lookbook, wholesale catalog, or homepage banner.
+**Aspect ratio:** 4:3 | **Resolution:** 2K
+
+> Arrange three skincare bottles in a staggered diagonal line on a pale terrazzo surface: a tall matte-white pump bottle, a medium frosted-glass toner spray, and a small glossy amber dropper bottle. Each label faces the camera with clean sans-serif typography visible. A large diffused beauty dish overhead provides shadowless even illumination, while a subtle backlight rim separates the bottles from the soft blush-pink background. Captured with a Fujifilm GFX 100S, 110mm f/2 at f/5.6, ensuring sharp label text and smooth tonal gradients across each bottle surface.

--- a/plugins/nano-banana-ultimate/skills/banana-people/SKILL.md
+++ b/plugins/nano-banana-ultimate/skills/banana-people/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: banana-people
+description: >-
+  People & portrait photography via Google Gemini (Nano Banana Ultimate).
+  Triggers on: portrait, headshot, lifestyle photo, people, person,
+  editorial photo, team photo, professional photo, face, human.
+allowed-tools: Bash(uv:*), Bash(ls:*), Read
+---
+
+# People & Portrait Photography
+
+**Input:** `$ARGUMENTS` (optional — subject description and scene)
+
+If `$ARGUMENTS` is provided, use it as the portrait brief and skip to prompt building. If empty, ask about the subject and setting.
+
+## Requirements
+
+- `uv` installed
+- `GEMINI_API_KEY` environment variable set (get one at https://aistudio.google.com/apikey)
+
+## Workflow
+
+1. **Understand** — Parse the user's request. Identify the subject (age, build, expression), setting, and intended use. If the subject or intent is unclear, ask ONE clarifying question.
+2. **Build prompt** — Construct a detailed Gemini prompt using the Prompt Formula below. Always describe clothing, environment, and camera distance explicitly.
+3. **Configure** — Choose aspect ratio, resolution, and lens based on the Domain Defaults table. Use defaults unless the user specifies otherwise.
+4. **Generate** — Run the script.
+5. **Deliver** — Report the saved file path. Do NOT read the image file back. Offer to iterate: adjust pose, lighting, framing, or prompt.
+
+## Prompt Formula
+
+Build every people/portrait prompt using this structure:
+
+```
+[Person: age/build/expression/clothing] + [Natural Action/Pose] + [Real-World Environment] + [Portrait Framing + Rule of Thirds] + [Natural Light Photography, specific lens]
+```
+
+### Rules
+
+- **Positive framing**: Describe what IS in the image, never what is absent.
+- **Strong verb opener**: Start with Capture, Photograph, Shoot, Frame, Compose.
+- **Clothing and environment**: Always describe what the person is wearing and the specific setting they are in.
+- **Camera distance**: Specify explicitly — close-up, medium shot, full-body, three-quarter length.
+- **Mood keywords**: Use "candid" for natural, spontaneous moments. Use "editorial" for styled, intentional compositions.
+- **No celebrity likenesses**: Never reference real public figures. Describe features generically (e.g., "a person in their 30s with short dark hair").
+
+## Domain Defaults
+
+| Domain | Aspect Ratio | Lens | Notes |
+|---|---|---|---|
+| Headshot | 3:4 | 85mm f/1.4 | Tight crop, shallow depth of field, subject fills frame |
+| Editorial / Lifestyle | 3:2 | 35mm f/2.0 | Environmental context, wider framing |
+| Group scene / Team | 16:9 | 24mm f/4.0 | Deep focus, everyone sharp |
+| **Resolution** | **2K** | | All people domains default to 2K |
+| **Lighting** | **Natural window light or golden hour** | | Soft, flattering, directional |
+
+## Generation
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/scripts/banana.py" \
+  --prompt "<detailed prompt following the formula>" \
+  --output "<YYYY-MM-DD-HH-MM-SS-descriptive-name>.png" \
+  --resolution 2K \
+  --aspect-ratio <ratio> \
+  --model gemini-3-pro-image-preview
+```
+
+## Editing (with input images)
+
+When the user provides an existing photo to modify (e.g., change background, adjust lighting, swap clothing):
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/scripts/banana.py" \
+  --prompt "<edit instruction: what to change AND what to keep>" \
+  --output "<YYYY-MM-DD-HH-MM-SS-descriptive-name>.png" \
+  --input-image "/path/to/source.png" \
+  --resolution 2K \
+  --aspect-ratio <ratio>
+```
+
+For edits, describe both the change and what must stay identical:
+> "Change the background to a warm golden-hour park scene. Keep the subject's face, expression, clothing, and pose exactly the same."
+
+Up to 14 input images can be passed (repeat `--input-image` for each).
+
+## Reference Prompts
+
+See [references/prompts.md](references/prompts.md) for ready-to-use example prompts covering headshots, lifestyle, editorial, group, and environmental portrait scenarios.

--- a/plugins/nano-banana-ultimate/skills/banana-people/references/prompts.md
+++ b/plugins/nano-banana-ultimate/skills/banana-people/references/prompts.md
@@ -1,0 +1,33 @@
+# People & Portrait — Example Prompts
+
+## 1. Professional Headshot
+**Use case:** LinkedIn, company directory, speaker bio | **Aspect ratio:** 3:4 | **Resolution:** 2K
+> Capture a confident professional headshot of a person in their early 40s wearing a tailored navy blazer over a white open-collar shirt. Medium close-up framed with the rule of thirds, subject positioned slightly off-center against a softly blurred neutral gray office background. Shot on 85mm f/1.4 lens with natural window light coming from the left, creating gentle catchlights in the eyes and soft shadows on the opposite cheek.
+
+## 2. Candid Lifestyle
+**Use case:** Brand storytelling, social media, blog hero | **Aspect ratio:** 3:2 | **Resolution:** 2K
+> Photograph a young woman in her late 20s wearing a linen sundress and woven sandals, laughing mid-step while carrying a canvas tote through a sun-drenched farmers market. Three-quarter length framing with shallow depth of field separating her from the colorful produce stalls behind. Shot on 35mm f/2.0 lens during golden hour, warm side light catching wisps of hair, candid and spontaneous mood.
+
+## 3. Editorial Fashion
+**Use case:** Magazine spread, lookbook, fashion campaign | **Aspect ratio:** 3:2 | **Resolution:** 2K
+> Compose an editorial fashion portrait of a tall person in their mid-20s wearing an oversized camel wool coat, black turtleneck, and wide-leg trousers, standing with one hand in a pocket on a minimalist concrete staircase. Full-body framing with strong geometric lines in the architecture creating leading lines toward the subject. Shot on 35mm f/2.0 lens with overcast diffused light for even, shadow-free skin tones, editorial and intentional styling.
+
+## 4. Team Group Shot
+**Use case:** Company about page, press kit, annual report | **Aspect ratio:** 16:9 | **Resolution:** 2K
+> Photograph a diverse group of six colleagues in smart-casual attire standing in a relaxed cluster on a rooftop terrace with a city skyline behind them. Wide framing with all faces sharp and in focus, subjects arranged at slightly staggered depths for visual interest. Shot on 24mm f/4.0 lens during late afternoon golden hour, warm backlight rimming their silhouettes while a reflector fills the front, candid smiles and natural body language.
+
+## 5. Environmental Portrait
+**Use case:** Feature article, documentary, personal branding | **Aspect ratio:** 3:2 | **Resolution:** 2K
+> Capture an environmental portrait of a ceramicist in their 50s wearing a clay-dusted apron over a rolled-sleeve denim shirt, hands resting on a freshly thrown bowl at the pottery wheel. Medium shot with the cluttered workshop — shelves of glazed pieces, bags of clay, wooden tools — visible but softly out of focus behind them. Shot on 35mm f/2.0 lens with natural north-facing window light illuminating the workspace, warm and authentic atmosphere.
+
+## 6. Street Photography Portrait
+**Use case:** Travel blog, urban culture editorial, social media | **Aspect ratio:** 3:2 | **Resolution:** 2K
+> Photograph a street musician in their 30s wearing a vintage leather jacket and worn jeans, playing an acoustic guitar while sitting on a wooden crate on a cobblestone side street. Three-quarter length framing with the narrow European alleyway stretching into soft bokeh behind them, old stone walls and hanging laundry adding texture. Shot on 35mm f/2.0 lens with late afternoon directional light casting long shadows, candid and documentary feel.
+
+## 7. Fitness Action
+**Use case:** Sports brand campaign, wellness blog, gym marketing | **Aspect ratio:** 3:2 | **Resolution:** 2K
+> Capture a dynamic action portrait of an athletic person in their late 20s wearing a fitted tank top and training shorts, mid-stride during an outdoor sprint along a waterfront boardwalk at sunrise. Full-body framing with a slight low angle emphasizing power and motion, water and horizon line in the background. Shot on 35mm f/2.0 lens with fast shutter speed freezing the movement, warm golden hour front light highlighting muscle definition and determination in the expression.
+
+## 8. Business Meeting
+**Use case:** Corporate website, SaaS marketing, investor deck | **Aspect ratio:** 16:9 | **Resolution:** 2K
+> Photograph two professionals in their 30s seated across from each other at a light oak conference table in a modern glass-walled meeting room. One person in a charcoal suit gestures while speaking, the other in a cream blouse listens attentively with a laptop open. Medium-wide framing with the clean, minimalist office environment and potted plants visible through the glass. Shot on 24mm f/4.0 lens with soft overhead panel lighting supplemented by natural window light from the right, professional and approachable mood.

--- a/plugins/nano-banana-ultimate/skills/banana-web/SKILL.md
+++ b/plugins/nano-banana-ultimate/skills/banana-web/SKILL.md
@@ -1,0 +1,87 @@
+---
+name: banana-web
+description: >-
+  Generate web design assets — hero backgrounds, landing page visuals, card images,
+  section dividers, and motion design keyframes with dark/light mode support.
+  Triggers on: web design, hero image, hero background, landing page background,
+  website asset, section graphic, UI mockup, web banner, motion design asset,
+  web illustration.
+allowed-tools: Bash(uv:*), Bash(ls:*), Read
+---
+
+# Web Design Assets
+
+**Input:** `$ARGUMENTS` (optional — asset type and visual description)
+
+If `$ARGUMENTS` is provided, use it as the design brief and skip to prompt building. If empty, ask about the asset type and theme.
+
+## Requirements
+
+- `uv` installed
+- `GEMINI_API_KEY` environment variable set (get one at https://aistudio.google.com/apikey)
+
+## Workflow
+
+1. **Understand** — Parse the user's request. Identify the asset type (hero, card, section divider, banner, motion keyframe), its placement context, and intended visual tone. Ask whether the asset targets **dark mode or light mode** if not specified. If the subject or intent is unclear, ask ONE clarifying question.
+2. **Build prompt** — Construct a detailed Gemini prompt using the Prompt Formula below. Ensure the prompt specifies negative space placement and focal point offset for headline overlay compatibility.
+3. **Configure** — Choose aspect ratio, resolution, and model based on the Asset Type Defaults table. Use defaults unless the user specifies otherwise.
+4. **Generate** — Run the script.
+5. **Deliver** — Report the saved file path. Do NOT read the image file back. Offer to iterate: adjust palette, composition, theme, or prompt.
+
+## Prompt Formula
+
+Build every web design asset prompt using this structure:
+
+```
+[UI Element/Scene] + [Visual Hierarchy Direction] + [Theme Context: dark/light] + [Wide Cinematic Composition] + [Modern Digital Art / Gradient Mesh / 3D Abstract]
+```
+
+### Rules
+
+- **Positive framing**: Describe what IS in the image, never what is absent.
+- **Strong verb opener**: Start with Design, Compose, Render, Create, Generate.
+- **Background-first thinking**: Generate assets that work as backgrounds — large negative space, non-centered focal point positioned to allow headline overlay.
+- **Dark/light mode awareness**: Always consider the target theme. Dark mode assets use deep bases (#0a0a0a to #1a1a2e) with luminous accents. Light mode assets use soft whites and pastels with subtle depth.
+- **Modern aesthetics**: Favor gradient meshes, abstract 3D shapes, glassmorphism elements, soft glows, and volumetric lighting.
+- **Composition**: Offset the focal point to one side or corner, leaving generous negative space for text content.
+
+## Asset Type Defaults
+
+| Asset Type | Aspect Ratio | Resolution | Notes |
+|---|---|---|---|
+| Hero background | 16:9 | 2K | Wide composition, focal point offset for headline overlay |
+| Card image | 3:2 | 1K | Contained composition, centered or subtly offset subject |
+| Section divider | 21:9 | 1K | Ultra-wide, horizontal flow, seamless horizontal tiling |
+| Motion keyframe | 16:9 | 2K | Dynamic composition, implied movement, animation-ready |
+
+## Generation
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/scripts/banana.py" \
+  --prompt "<detailed prompt following the formula>" \
+  --output "<YYYY-MM-DD-HH-MM-SS-descriptive-name>.png" \
+  --resolution <1K|2K> \
+  --aspect-ratio <ratio> \
+  --model gemini-3-pro-image-preview
+```
+
+## Editing (with input images)
+
+When the user provides an existing asset to modify (e.g., change palette, swap theme, adjust composition):
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/scripts/banana.py" \
+  --prompt "<edit instruction: what to change AND what to keep>" \
+  --output "<YYYY-MM-DD-HH-MM-SS-descriptive-name>.png" \
+  --input-image "/path/to/source.png" \
+  --aspect-ratio <ratio>
+```
+
+For edits, describe both the change and what must stay identical:
+> "Convert this hero background to dark mode — shift the base to deep navy, change accent colors to luminous cyan. Keep the composition, shapes, and layout exactly the same."
+
+Up to 14 input images can be passed (repeat `--input-image` for each).
+
+## Reference Prompts
+
+See [references/prompts.md](references/prompts.md) for ready-to-use example prompts covering hero backgrounds, card illustrations, section dividers, dashboard mockups, and gradient mesh compositions for both dark and light themes.

--- a/plugins/nano-banana-ultimate/skills/banana-web/references/prompts.md
+++ b/plugins/nano-banana-ultimate/skills/banana-web/references/prompts.md
@@ -1,0 +1,29 @@
+# Web Design Asset — Reference Prompts
+
+## 1. Dark Hero Gradient Background
+**Use case:** SaaS or tech landing page hero section (dark mode) | **Aspect ratio:** 16:9 | **Resolution:** 2K
+> Design a dark hero background with a deep navy-to-black gradient base (#0a0a2e to #0d0d0d). Place a luminous indigo and cyan gradient mesh in the lower-right quadrant, softly bleeding toward the center. Add subtle floating orbs of translucent purple glass with volumetric light scattering. Keep the upper-left two-thirds as clean negative space for headline overlay. Modern digital art style with smooth anti-aliased edges.
+
+## 2. Light Hero Abstract Shapes
+**Use case:** Creative agency or portfolio hero section (light mode) | **Aspect ratio:** 16:9 | **Resolution:** 2K
+> Compose a light hero background on a warm off-white base (#f8f6f3). Scatter soft 3D abstract shapes — a matte peach torus, a translucent mint sphere, and a pale lavender rounded cube — grouped in the lower-right area with long diffused shadows. Use soft studio lighting from the upper left. Keep the left half open and minimal for headline text placement. Clean modern digital art with pastel gradient fills and subtle grain texture.
+
+## 3. Card Illustration
+**Use case:** Feature card or blog post thumbnail | **Aspect ratio:** 3:2 | **Resolution:** 1K
+> Create a compact card illustration with a soft gradient background shifting from pale sky blue to light violet. Place a stylized 3D isometric browser window in the center with glassmorphism frosted panels and a subtle green accent glow along its edges. Add tiny floating geometric particles — circles and diamonds — around the browser. Modern flat 3D style with rounded corners and soft ambient occlusion.
+
+## 4. Section Divider
+**Use case:** Visual break between landing page sections | **Aspect ratio:** 21:9 | **Resolution:** 1K
+> Render an ultra-wide section divider with a smooth horizontal gradient flowing from deep slate (#1e293b) on the left through a rich teal accent band in the center to deep slate on the right. Add a thin luminous line of electric blue running horizontally through the middle with soft glow falloff. Scatter micro-dots of white light along the line to suggest data flow. Minimal, modern digital art with clean horizontal movement.
+
+## 5. SaaS Dashboard Mockup Background
+**Use case:** Product screenshot backdrop or feature section background | **Aspect ratio:** 16:9 | **Resolution:** 2K
+> Design a dark contextual background for a SaaS product section. Use a rich charcoal base (#141420) with a subtle radial gradient of deep purple emanating from the center. Place soft, out-of-focus abstract 3D chart shapes — bar clusters and curved lines — in the background at 15% opacity to suggest analytics without competing with a foreground screenshot. Add a faint grid pattern overlay. Modern digital art with volumetric fog and depth of field blur.
+
+## 6. Gradient Mesh Background
+**Use case:** Multi-purpose hero or section background (light mode) | **Aspect ratio:** 16:9 | **Resolution:** 2K
+> Generate a smooth gradient mesh background on a clean white base. Blend four soft color pools: warm coral in the top-right corner, pale gold in the bottom-right, soft lavender in the bottom-left, and cool mint in the top-left. Each pool fades gently into the white center, creating an airy open space for text overlay. Apply a fine noise grain texture at 3% opacity for a tactile, modern feel. Soft luminous digital art with seamless color transitions.
+
+## 7. Testimonial Section Background
+**Use case:** Social proof or testimonial section backdrop (dark mode) | **Aspect ratio:** 16:9 | **Resolution:** 2K
+> Compose a dark testimonial section background with a near-black base (#0f0f14). Place a large, subtle gradient mesh of muted indigo and dark teal in the center, keeping it low-contrast so it does not overpower overlaid quote text. Add two or three softly glowing abstract ring shapes at varying sizes, positioned off-center with gentle bokeh blur. Include a faint horizontal line pattern at 5% opacity for subtle texture. Elegant modern digital art with restrained luminosity and deep atmosphere.

--- a/plugins/nano-banana-ultimate/skills/banana-youtube/SKILL.md
+++ b/plugins/nano-banana-ultimate/skills/banana-youtube/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: banana-youtube
+description: >-
+  Generate bold, high-contrast YouTube thumbnail images with dramatic framing,
+  exaggerated expressions, and click-optimized compositions via Gemini.
+  Triggers on: youtube thumbnail, thumbnail, youtube, video thumbnail,
+  yt thumbnail, video cover image, click-worthy thumbnail.
+allowed-tools: Bash(uv:*), Bash(ls:*), Read
+---
+
+# YouTube Thumbnail Maker
+
+**Input:** `$ARGUMENTS` (optional — video topic or thumbnail description)
+
+If `$ARGUMENTS` is provided, use it as the video topic and skip to prompt building. If empty, ask what the video is about.
+
+## Requirements
+
+- `uv` installed
+- `GEMINI_API_KEY` environment variable set (get one at https://aistudio.google.com/apikey)
+
+## Workflow
+
+1. **Understand** — Parse the user's request. Identify the video topic, target emotion, and channel style. If the subject or intent is unclear, ask ONE clarifying question.
+2. **Build prompt** — Construct a detailed Gemini prompt using the Prompt Formula below. Prioritize dramatic facial expressions, bold colors, and high visual contrast.
+3. **Configure** — ALWAYS use 16:9, 2K, and the Pro model. These are non-negotiable for thumbnails.
+4. **Generate** — Run the script.
+5. **Deliver** — Report the saved file path. Do NOT read the image file back. Offer to iterate: adjust expression, background color, composition, or prompt.
+
+## Prompt Formula
+
+Build every thumbnail prompt using this structure:
+
+```
+[Subject with Expression] + [Dramatic Reaction/Gesture] + [Bold Colored Background] + [Close-Up Rule-of-Thirds] + [Hyper-Saturated Photography with Rim Lighting]
+```
+
+### Rules
+
+- **Positive framing**: Describe what IS in the image, never what is absent.
+- **Strong verb opener**: Start with Generate, Create, Capture, Render, Design, Compose.
+- **Faces sell clicks**: Always include a face with an exaggerated expression — wide eyes, open mouth, raised eyebrows, shocked grin.
+- **Bold backgrounds**: Use solid, saturated colors (electric blue, hot pink, neon green, deep orange) or dramatic gradients.
+- **Rim lighting**: Add a strong backlight or rim light to separate the subject from the background and create a cinematic pop.
+- **Text space**: Reserve approximately one-third of the frame for text overlay — typically the opposite side from the subject.
+- **No celebrity likenesses**: Never reference real public figures. Describe features generically.
+
+## Defaults
+
+| Parameter    | Default                        |
+|--------------|--------------------------------|
+| Aspect ratio | 16:9                           |
+| Resolution   | 2K                             |
+| Model        | gemini-3-pro-image-preview     |
+
+ALWAYS use these defaults. Thumbnails require widescreen, high resolution, and the Pro model for maximum quality. Do not downgrade.
+
+## Thumbnail Psychology
+
+- **Faces with exaggerated expressions drive clicks.** A shocked, excited, or curious face is the single strongest thumbnail element. Always make the expression bigger than real life.
+- **Place the subject on the left or right third.** Use rule-of-thirds positioning to leave space for title text on the opposite side.
+- **High saturation, deep contrast.** Thumbnails are viewed at small sizes on crowded feeds. Muted tones disappear. Push saturation and contrast to make the image pop at 120px tall.
+- **Shallow depth of field.** Blur the background aggressively to make the subject the undeniable focal point.
+- **Reserve ~1/3 of the frame for text overlay.** The creator will add bold text in post — leave clean, uncluttered space for it.
+
+## Common Video Genres
+
+| Genre          | Subject Guidance                                      | Background Style                        | Expression / Gesture                    |
+|----------------|-------------------------------------------------------|-----------------------------------------|-----------------------------------------|
+| Tech review    | Person holding the device, angled toward camera       | Electric blue or dark gradient           | Wide-eyed amazement, mouth slightly open |
+| Cooking        | Chef holding the finished dish at eye level           | Warm orange or kitchen bokeh             | Proud smile, steam rising from plate     |
+| Travel         | Traveler with arms wide open, scenic landmark behind  | Vivid sky or sunset gradient             | Joyful awe, looking into the distance    |
+| Tutorial       | Person pointing at a floating code block or diagram   | Deep purple or dark teal                 | Confident nod, direct eye contact        |
+| Fitness        | Athlete mid-motion, muscles defined, sweat visible    | Bold red or neon green                   | Intense determination, clenched jaw      |
+| Unboxing       | Hands lifting the product out of the box              | Bright yellow or white spotlight         | Surprised delight, eyebrows raised       |
+| Storytime      | Person leaning toward camera, conspiratorial angle    | Moody dark background with spotlight     | Whispered secret expression, wide eyes   |
+| Reaction       | Person recoiling or leaning back in shock             | Hot pink or chaotic gradient             | Jaw dropped, hands on cheeks             |
+| Educational    | Presenter beside a whiteboard or floating infographic | Clean white or soft blue                 | Thoughtful curiosity, finger raised      |
+
+## Generation
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/scripts/banana.py" \
+  --prompt "<detailed prompt following the formula>" \
+  --output "<YYYY-MM-DD-HH-MM-SS-descriptive-name>.png" \
+  --resolution 2K \
+  --aspect-ratio 16:9 \
+  --model gemini-3-pro-image-preview
+```
+
+## Editing (with input images)
+
+When the user provides an existing image to modify (e.g., swap a background, change expression, adjust colors):
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/scripts/banana.py" \
+  --prompt "<edit instruction: what to change AND what to keep>" \
+  --output "<YYYY-MM-DD-HH-MM-SS-descriptive-name>.png" \
+  --input-image "/path/to/source.png" \
+  --resolution 2K \
+  --aspect-ratio 16:9
+```
+
+For edits, describe both the change and what must stay identical:
+> "Change the background to a bold neon green gradient. Keep the subject's face, expression, clothing, and pose exactly the same."
+
+Up to 14 input images can be passed (repeat `--input-image` for each).
+
+## References
+
+See [references/prompts.md](references/prompts.md) for ready-to-use example prompts covering common YouTube thumbnail scenarios across multiple video genres.

--- a/plugins/nano-banana-ultimate/skills/banana-youtube/references/prompts.md
+++ b/plugins/nano-banana-ultimate/skills/banana-youtube/references/prompts.md
@@ -1,0 +1,41 @@
+# YouTube Thumbnail — Example Prompts
+
+## 1. Tech Review
+**Use case:** New gadget review or comparison video | **Aspect ratio:** 16:9 | **Resolution:** 2K
+> Generate a hyper-saturated close-up photograph of a person in their late 20s with short dark hair, eyes wide open in amazement, mouth forming a surprised "O", holding a sleek matte-black smartphone angled toward the camera. Electric blue background with subtle radial gradient. Strong white rim lighting separating the subject from the background, shallow depth of field, shot on 50mm f/1.4 lens. The right third of the frame is clean open space for text overlay.
+
+## 2. Cooking Recipe
+**Use case:** Recipe walkthrough or food challenge | **Aspect ratio:** 16:9 | **Resolution:** 2K
+> Create a vibrant close-up photograph of a chef in a white apron holding a steaming golden-brown lasagna at eye level, proud confident smile with raised eyebrows, warm orange bokeh background with floating steam particles. Hyper-saturated colors, glistening melted cheese with visible pull, dramatic side lighting from the left creating deep shadows, shallow depth of field. Subject positioned on the left third, right third reserved for text overlay.
+
+## 3. Travel Vlog
+**Use case:** Destination reveal or travel highlights | **Aspect ratio:** 16:9 | **Resolution:** 2K
+> Capture a dynamic photograph of a young traveler standing with arms wide open on a cliffside overlook, jaw dropped in awe, wind-blown hair, wearing a bright red jacket against a vivid sunset sky exploding with orange, pink, and purple gradients. Strong golden-hour rim lighting outlines the subject, hyper-saturated landscape colors, dramatic clouds in the background. Subject placed on the right third, left third open with clean sky for text overlay, shot on 35mm f/2.0 lens.
+
+## 4. Coding Tutorial
+**Use case:** Programming walkthrough or tech explainer | **Aspect ratio:** 16:9 | **Resolution:** 2K
+> Design a punchy close-up photograph of a developer in their 30s wearing glasses and a dark hoodie, pointing confidently at the camera with a knowing smirk and one raised eyebrow, deep purple background with faint glowing code syntax floating behind them in teal and green. Crisp rim lighting in cool white along the subject's shoulders and hair, high contrast, shallow depth of field blurring the code elements. Subject on the left third, right third clean for title text.
+
+## 5. Fitness Transformation
+**Use case:** Before/after reveal or workout challenge | **Aspect ratio:** 16:9 | **Resolution:** 2K
+> Render an intense close-up photograph of an athletic person mid-bicep-curl, veins visible on forearms, jaw clenched with fierce determination, sweat glistening on their forehead, wearing a sleeveless neon green tank top. Bold red background with dramatic spotlight from above, strong dual rim lighting in warm orange outlining their silhouette, hyper-saturated skin tones, shallow depth of field. Subject fills the left two-thirds, right third is solid background for text overlay.
+
+## 6. Unboxing
+**Use case:** Product launch or mystery unboxing | **Aspect ratio:** 16:9 | **Resolution:** 2K
+> Generate a dynamic photograph of two hands lifting a glossy white product out of a matte black premium box, tissue paper spilling over the edges, bright yellow spotlight background with radial gradient fading to warm gold. The person behind the box has eyebrows raised sky-high, mouth open in delighted surprise, eyes sparkling. Strong overhead key light creating sharp shadows inside the box, hyper-saturated colors, shallow depth of field on the product. Hands and box centered, face visible in upper third.
+
+## 7. Storytime
+**Use case:** Personal story, drama, or confession video | **Aspect ratio:** 16:9 | **Resolution:** 2K
+> Create a moody close-up photograph of a person in their mid-20s leaning toward the camera at a conspiratorial angle, eyes wide with a secretive half-smile, one hand cupped beside their mouth as if whispering. Dark charcoal background with a single warm spotlight creating a dramatic vignette around their face. Strong warm rim lighting on one side, cool blue fill light on the other, high contrast, shallow depth of field. Subject on the right third, left third dark and clean for text overlay.
+
+## 8. Before/After
+**Use case:** Transformation, makeover, or renovation reveal | **Aspect ratio:** 16:9 | **Resolution:** 2K
+> Compose a split-composition thumbnail photograph with a sharp diagonal divide. Left side shows a person with messy unkempt hair, tired expression, wearing a wrinkled grey t-shirt under flat overcast lighting. Right side shows the same person with styled hair, beaming confident grin, wearing a crisp blazer under warm golden studio lighting with strong rim light. Bold hot pink dividing line between the two halves. Hyper-saturated contrast between the dull left and vibrant right, shallow depth of field on both sides.
+
+## 9. Reaction
+**Use case:** Reacting to viral content, reveals, or shocking news | **Aspect ratio:** 16:9 | **Resolution:** 2K
+> Generate an extreme close-up photograph of a person recoiling backward with both hands pressed against their cheeks, jaw fully dropped, eyebrows shooting up, pupils dilated in pure shock. Chaotic gradient background blending hot pink, electric orange, and deep magenta. Aggressive rim lighting in neon cyan outlining the subject's silhouette, motion blur on the hair suggesting sudden movement, hyper-saturated skin tones, ultra-shallow depth of field. Subject centered with equal space on both sides for text.
+
+## 10. Educational Explainer
+**Use case:** Science breakdown, history lesson, or how-it-works video | **Aspect ratio:** 16:9 | **Resolution:** 2K
+> Design a clean, authoritative photograph of a presenter in their 40s wearing a navy blazer, standing beside a floating translucent infographic panel with glowing data visualizations in teal and white. One index finger raised in a "key point" gesture, expression showing thoughtful curiosity with a slight head tilt and focused gaze. Soft blue gradient background, bright studio key light from the front, subtle warm rim light separating the subject from the background. Subject on the left third, infographic and open space on the right third for text overlay.

--- a/plugins/nano-banana-ultimate/skills/banana/SKILL.md
+++ b/plugins/nano-banana-ultimate/skills/banana/SKILL.md
@@ -1,0 +1,111 @@
+---
+name: banana
+description: >-
+  Generate or edit images via Google Gemini (Nano Banana Ultimate).
+  Text-to-image generation and multi-image editing with up to 14 input references.
+  Triggers on: generate image, create image, edit image, make a picture,
+  draw, render, visualize, banana, create visual.
+allowed-tools: Bash(uv:*), Bash(ls:*), Read
+---
+
+# Nano Banana Ultimate — Image Generation
+
+**Input:** `$ARGUMENTS` (optional plain-language description of what to generate)
+
+If `$ARGUMENTS` is provided, use it as the user's intent and skip to prompt building. If empty, ask a clarifying question.
+
+## Requirements
+
+- `uv` installed
+- `GEMINI_API_KEY` environment variable set (get one at https://aistudio.google.com/apikey)
+
+## Workflow
+
+1. **Understand** — Parse the user's request. If the subject or intent is unclear, ask ONE clarifying question.
+2. **Build prompt** — Construct a detailed Gemini prompt using the formula below.
+3. **Configure** — Choose aspect ratio, resolution, and model. Use defaults unless the user specifies otherwise.
+4. **Generate** — Run the script.
+5. **Deliver** — Report the saved file path. Do NOT read the image file back. Offer to iterate: adjust style, composition, or prompt.
+
+## Prompt Formula
+
+Build every prompt using this structure:
+
+```
+[Subject] + [Action/Pose] + [Environment/Location] + [Composition/Framing] + [Style/Medium]
+```
+
+### Rules
+
+- **Positive framing**: Describe what IS in the image, never what is absent. Say "empty street" not "no cars".
+- **Strong verb opener**: Start with Generate, Create, Capture, Render, Design, Compose.
+- **Be specific**: Include concrete details — materials, lighting direction, time of day, textures.
+- **Camera/lens** (photorealistic): "shot on 85mm f/1.4 lens", "low angle", "aerial view".
+- **Lighting**: "golden hour side light", "studio softbox", "dramatic chiaroscuro", "overcast diffused".
+- **Materiality**: "brushed aluminum", "matte ceramic", "glossy lacquer", "translucent glass".
+- **Text in images**: Enclose any text to render in quotes. Specify font style. Note: text rendering may be imperfect.
+
+## Generation
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/scripts/banana.py" \
+  --prompt "<detailed prompt>" \
+  --output "<YYYY-MM-DD-HH-MM-SS-descriptive-name>.png" \
+  --resolution <1K|2K|4K> \
+  --aspect-ratio <ratio> \
+  --model <model>
+```
+
+## Editing (with input images)
+
+When the user provides an existing image to modify:
+
+```bash
+uv run "${CLAUDE_PLUGIN_ROOT}/scripts/banana.py" \
+  --prompt "<edit instruction: what to change AND what to keep>" \
+  --output "<output-path>.png" \
+  --input-image "/path/to/source.png"
+```
+
+For edits, describe both the change and what must stay identical:
+> "Change the background to a sunset beach. Keep the subject, their clothing, and pose exactly the same."
+
+## Defaults
+
+| Parameter | Default |
+|---|---|
+| Resolution | 1K |
+| Aspect ratio | 1:1 |
+| Model | gemini-3-pro-image-preview |
+
+## Models
+
+| Model | Best for |
+|---|---|
+| `gemini-3-pro-image-preview` | Final output, complex scenes, high quality (Nano Banana Pro) |
+| `gemini-3.1-flash-image-preview` | Fast drafts, iterations, simple images (Nano Banana 2) |
+
+## Aspect Ratios
+
+| Ratio | Use case |
+|---|---|
+| 1:1 | Social squares, logos, icons |
+| 3:2 | Photography standard |
+| 2:3 | Book covers, tall portraits |
+| 4:3 | Landscape, presentations |
+| 3:4 | Portrait photos, Pinterest |
+| 16:9 | YouTube thumbnails, widescreen |
+| 9:16 | Stories, Reels, TikTok |
+| 4:5 | Instagram portrait |
+| 5:4 | Large format print |
+| 21:9 | Ultrawide banners |
+
+## Output Naming
+
+Always use timestamped filenames: `YYYY-MM-DD-HH-MM-SS-descriptive-name.png`
+
+Save to the current working directory unless the user specifies a path.
+
+## References
+
+See [references/prompts.md](references/prompts.md) for ready-to-use example prompts covering landscapes, abstract art, interiors, sci-fi, nature, fantasy, still life, and underwater scenes.

--- a/plugins/nano-banana-ultimate/skills/banana/references/prompts.md
+++ b/plugins/nano-banana-ultimate/skills/banana/references/prompts.md
@@ -1,0 +1,76 @@
+# General Image Generation — Example Prompts
+
+Prompts follow the Google formula:
+**[Subject] + [Action] + [Location] + [Composition] + [Style]**
+
+---
+
+## 1. Cinematic Landscape
+
+**Use case:** Desktop wallpaper, presentation background, creative project
+**Aspect ratio:** 16:9 | **Resolution:** 2K
+
+> Capture a sweeping aerial view of a winding river cutting through an autumn forest, golden and crimson foliage stretching to the horizon under a dramatic sky of layered cumulus clouds lit from below by the setting sun. Wide cinematic composition with the river entering from the bottom-left corner and curving toward the upper-right third. Shot on a drone with a 24mm wide-angle lens, golden hour lighting casting long shadows across the canopy.
+
+---
+
+## 2. Abstract Art
+
+**Use case:** Album cover, poster, social media art
+**Aspect ratio:** 1:1 | **Resolution:** 2K
+
+> Generate a bold abstract composition of intersecting geometric planes in deep crimson, midnight blue, and burnished gold, layered with translucent gradients and sharp diagonal lines. A single circle of warm amber light glows at the intersection point. Centered balanced composition with high contrast and rich texture, inspired by constructivist painting with a modern digital finish.
+
+---
+
+## 3. Cozy Interior Scene
+
+**Use case:** Blog hero image, lifestyle content, mood board
+**Aspect ratio:** 4:3 | **Resolution:** 1K
+
+> Render a cozy reading nook with a deep emerald velvet armchair beside a floor-to-ceiling window, rain streaking down the glass. A warm throw blanket drapes over the armrest, a steaming ceramic mug sits on a small oak side table, and a stack of hardcover books rests on the floor. Soft warm lamplight from the left fills the scene with golden tones, shallow depth of field blurring the rain outside.
+
+---
+
+## 4. Sci-Fi Concept
+
+**Use case:** Game art, book cover, concept visualization
+**Aspect ratio:** 16:9 | **Resolution:** 2K
+
+> Design a futuristic cityscape at twilight with towering crystalline skyscrapers reflecting neon cyan and magenta light, hovering transport vehicles tracing light trails between buildings. A lone figure in a dark coat stands on a rain-slicked observation deck in the foreground, silhouetted against the glowing skyline. Wide cinematic composition with dramatic depth, cyberpunk digital painting style with volumetric fog and lens flare.
+
+---
+
+## 5. Nature Close-Up
+
+**Use case:** Print art, calendar image, stock photography
+**Aspect ratio:** 3:2 | **Resolution:** 2K
+
+> Photograph an extreme macro close-up of morning dew drops on a spider web, each droplet acting as a tiny lens refracting the blurred green and gold garden behind it. The silk strands catch rim light from the rising sun entering from the upper right. Shot on a 100mm macro lens at f/2.8, tack-sharp focus on the central cluster of droplets with creamy bokeh dissolving into soft warm light.
+
+---
+
+## 6. Fantasy Character
+
+**Use case:** D&D character art, game asset, illustration
+**Aspect ratio:** 3:4 | **Resolution:** 2K
+
+> Create a portrait of a forest ranger elf with silver-streaked auburn hair, wearing weathered olive leather armor with hand-stitched leaf patterns. They stand in a misty ancient forest clearing, one hand resting on a carved wooden bow, gaze steady and calm. Three-quarter framing with soft dappled light filtering through the canopy above. Digital painting in a semi-realistic fantasy illustration style with rich earth tones and atmospheric haze.
+
+---
+
+## 7. Minimalist Still Life
+
+**Use case:** Art print, home decor, editorial
+**Aspect ratio:** 1:1 | **Resolution:** 1K
+
+> Compose a minimalist still life of three smooth river stones stacked in a cairn on a pale sand surface, casting a single long shadow from directional light entering from the left. Muted palette of warm grey, sand beige, and soft white. Clean centered composition with generous negative space above and to the right. Shot on medium format film with fine grain, evoking calm and simplicity.
+
+---
+
+## 8. Underwater Scene
+
+**Use case:** Travel content, nature documentary frame, creative project
+**Aspect ratio:** 16:9 | **Resolution:** 2K
+
+> Capture a vibrant coral reef scene with a sea turtle gliding gracefully through sun-dappled turquoise water, schools of yellow tang fish scattered around branching coral formations in vivid orange, purple, and teal. Shafts of golden sunlight penetrate from the surface above, illuminating particles suspended in the water. Wide underwater composition with the turtle positioned on the left third, shot with a wide-angle underwater housing at f/8 for deep focus.


### PR DESCRIPTION
## Summary

- Adds **nano-banana-ultimate**, the most complete image generation plugin for Claude Code — users describe what they want in plain language, the plugin auto-builds an optimized prompt using Google's official Nano Banana prompting best practices and calls the Gemini API
- Ships 8 domain-specialized skills (ads, web, YouTube thumbnails, illustration, logo, people, objects + catch-all) each with domain defaults, 63 curated reference prompts, and input-image editing support — all sharing a single validated Python script
- Resolves all critical and high issues identified in QA review: broken script invocations, missing `--output` flags, no editing support in domain skills, missing `$ARGUMENTS` passthrough, and incorrect Flash model ID (`gemini-3.1-flash-image-preview`)

## Test plan

- [x] Install plugin: `/plugin install nano-banana-ultimate@devx-plugins`
- [x] Set `GEMINI_API_KEY` and verify `uv` is available
- [x] Test catch-all: `/banana a red cube on white background`
- [x] Test domain routing: `/banana-youtube coding tutorial thumbnail` — should auto-build prompt and generate 16:9 2K image
- [x] Test editing: `/banana` with an `--input-image` reference — should modify image and preserve unchanged elements
- [x] Test quick invocation: `/banana-logo minimal fintech startup in deep blue` — should skip clarifying questions and generate directly
- [x] Verify Nano Banana 2 (Flash): explicitly pass `--model gemini-3.1-flash-image-preview` and confirm generation succeeds
- [x] Confirm output is a valid PNG saved to current directory with timestamped filename