### PR TITLE
feat(qa): add code review and appsec review skills

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,8 +21,8 @@
     },
     {
       "name": "devx-qa",
-      "description": "Quality assurance toolkit to analyze your codebase, review code, and manage CLAUDE.md memory",
-      "version": "1.2.0",
+      "description": "Quality assurance toolkit to analyze codebases, review code changes, perform focused appsec reviews, audit React patterns, and improve skills",
+      "version": "1.4.0",
       "author": {
         "name": "Pierre Tomasina",
         "email": "contact@dev3o.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -54,6 +54,6 @@ Inline bash execution uses `!` syntax: `!`git status``
 | Plugin | Purpose | Commands |
 |--------|---------|----------|
 | devx-git | Git workflow automation | `/commit`, `/pr` (skills) |
-| devx-qa | Architecture analysis, skill improvement & React auditing | `/explaining-architecture`, `/skill-fixer`, `/fixing-react-antipatterns` (skills) |
+| devx-qa | Architecture analysis, code review, appsec review, skill improvement & React auditing | `/explaining-architecture`, `/code-review`, `/appsec-review`, `/skill-fixer`, `/fixing-react-antipatterns` (skills) |
 | secrets-guard | Block access to secret/sensitive files | hooks only |
 | landing-page | Structured copywriting & Astro 5 landing pages | `/writing-landing-page-copy`, `/building-landing-page` (skills) |

--- a/README.md
+++ b/README.md
@@ -64,7 +64,7 @@ Every command in this marketplace comes from real, daily usage — refined over 
 | Plugin | What it does | Install |
 |--------|-------------|---------|
 | [**devx-git**](plugins/git/) | Conventional commits & PR creation (skills: `/commit`, `/pr`) | `/plugin install devx-git@devx-plugins` |
-| [**devx-qa**](plugins/qa/) | Architecture analysis with ASCII diagrams & skill improvement | `/plugin install devx-qa@devx-plugins` |
+| [**devx-qa**](plugins/qa/) | Architecture analysis, code review, appsec review & React/skill audits | `/plugin install devx-qa@devx-plugins` |
 | [**secrets-guard**](plugins/secrets-guard/) | Blocks Claude from accessing sensitive files (70+ patterns) | `/plugin install secrets-guard@devx-plugins` |
 | [**landing-page**](plugins/landing-page/) | Structured copywriting & Astro 5 landing page generation | `/plugin install landing-page@devx-plugins` |
 | [**nano-banana-ultimate**](plugins/nano-banana-ultimate/) | Image generation via Gemini with 8 domain-specialized skills | `/plugin install nano-banana-ultimate@devx-plugins` |

--- a/plugins/qa/.claude-plugin/plugin.json
+++ b/plugins/qa/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "devx-qa",
-  "description": "Quality assurances toolkit to analyse deeply your codebase, review the code and basic security check",
-  "version": "1.2.0",
+  "description": "Quality assurance toolkit to analyze codebases, review code changes, perform focused appsec reviews, audit React patterns, and improve skills",
+  "version": "1.4.0",
   "author": {
     "name": "Pierre Tomasina",
     "email": "contact@dev3o.com"

--- a/plugins/qa/README.md
+++ b/plugins/qa/README.md
@@ -1,6 +1,6 @@
 # devx-qa
 
-Code quality tools for understanding and maintaining projects.
+Code quality tools for reviewing changes, understanding architecture, performing focused appsec reviews, and maintaining projects.
 
 ## Installation
 
@@ -41,6 +41,46 @@ show me the architecture
 ```
 
 No mermaid. No external tools. Just ASCII that works everywhere.
+
+---
+
+### code-review
+
+Reviews pull requests and code changes for correctness, conventions, maintainability, performance, tests, and security. Triggers when you ask for a code review, PR review, feedback on a diff, or to check code quality.
+
+```
+review this PR 42
+review my staged changes
+check code quality in src/auth
+```
+
+**What happens:**
+1. Resolves the review target (PR, local diff, commit range, or path)
+2. Uses `gh pr list`, `gh pr view`, and `gh pr diff` for GitHub PR reviews when relevant
+3. Reads the changed files with surrounding context
+4. Checks correctness, conventions, performance, tests, and security
+5. Returns findings-first feedback grouped by: Must fix, Should fix, Nit
+
+---
+
+### appsec-review
+
+Performs a focused application security review of pull requests and branch diffs. Triggers when you ask for a security review of a PR, diff, or branch, or want only exploitable auth, injection, data exposure, and trust-boundary issues.
+
+```
+security review this PR
+audit this branch for vulnerabilities
+check this diff for auth or injection bugs
+```
+
+**What happens:**
+1. Resolves the review scope from a PR, local branch, or commit range
+2. Reads nearby auth, validation, tenant, rendering, and data-flow code for context
+3. Generates candidate vulnerabilities, then filters false positives with a second pass
+4. Reports only HIGH and MEDIUM findings with confidence `>= 8/10`
+5. Returns markdown only, or states that no high-confidence appsec findings were found
+
+Includes a playbook for TypeScript/Node, Python, Rust, and modern web app attack surfaces.
 
 ---
 

--- a/plugins/qa/skills/appsec-review/SKILL.md
+++ b/plugins/qa/skills/appsec-review/SKILL.md
@@ -1,0 +1,97 @@
+---
+name: appsec-review
+description: This skill should be used when the user asks to "security review this PR", "review this diff for vulnerabilities", "appsec review these changes", "audit this branch for auth, injection, or data exposure bugs", "check this code for exploitable security issues", or requests a focused application security review of pending changes.
+---
+
+# Application Security Review
+
+Target: `$ARGUMENTS` (optional PR number, branch, commit range, or path; default to the current branch against the remote default branch)
+
+## Objective
+
+Review only newly introduced application-layer vulnerabilities in the requested change set. Optimize for high-confidence, exploitable findings with real attacker value. Think in terms of trust boundaries, attacker-controlled inputs, privilege changes, unsafe parsing, outbound request control, data exposure, and framework-specific behavior across TypeScript, Node.js, Python, Rust, and modern web stacks.
+
+Favor signal over coverage. Missing a speculative issue is better than shipping a noisy report.
+
+## Workflow
+
+Progress checklist:
+
+```text
+Application Security Review:
+- [ ] Step 1: Resolve the review scope
+- [ ] Step 2: Build repository security context
+- [ ] Step 3: Generate candidate vulnerabilities
+- [ ] Step 4: Filter false positives in parallel
+- [ ] Step 5: Publish the final markdown report
+```
+
+### Step 1: Resolve the Review Scope
+
+- If `$ARGUMENTS` looks like a PR number and GitHub context is available, gather the PR metadata first and review that diff.
+- Otherwise resolve the local review base from `origin/HEAD`. If the default branch is unclear, inspect `git remote show origin`.
+- Capture the complete review context:
+  - `git status`
+  - `git diff --name-only <base>...HEAD`
+  - `git log --no-decorate <base>...HEAD`
+  - `git diff <base>...HEAD`
+- Use `git show <commit>` when a suspicious commit needs narrower intent or before/after context.
+- If remote comparison is unavailable, fall back to staged plus unstaged local diff and say so explicitly in the review setup.
+
+### Step 2: Build Repository Security Context
+
+- Read adjacent code instead of reviewing the raw diff in isolation.
+- Identify the stack, auth model, tenant model, validation patterns, templating paths, serializers, and secret-handling conventions used near the changed files.
+- Compare the new code against nearby secure patterns before declaring a finding.
+- Load `references/review-playbook.md` for threat-model questions, attack-surface coverage, and stack-specific heuristics.
+
+### Step 3: Generate Candidate Vulnerabilities
+
+- Launch one readonly sub-task dedicated to finding candidate vulnerabilities across the entire change set.
+- Use the investigator prompt in `references/subtask-templates.md`.
+- Require the sub-task to return candidates only when there is:
+  - a changed code location
+  - a concrete exploit path
+  - meaningful impact
+  - preliminary confidence from 7 to 10
+- Prefer categories such as `authz_bypass`, `sql_injection`, `nosql_injection`, `command_injection`, `path_traversal`, `unsafe_deserialization`, `xss`, `ssrf`, `jwt`, `data_exposure`, or `crypto_misuse`.
+
+### Step 4: Filter False Positives in Parallel
+
+- Create one readonly validation sub-task per candidate and launch them in parallel.
+- Use the validator prompt in `references/subtask-templates.md`.
+- Load `references/false-positive-filter.md` inside each validator task.
+- Instruct each validator to challenge the candidate aggressively and reject it unless the exploit path is concrete, introduced by the change set, and still valid after considering framework protections and surrounding code.
+- If sub-tasks are unavailable, run the same investigator and validator flow inline and validate candidates sequentially with the same filtering bar.
+
+### Step 5: Publish the Final Markdown Report
+
+- Keep only findings with confidence `>= 8/10` after validation.
+- Report HIGH and MEDIUM only.
+- If no findings survive, say so plainly.
+- Output markdown only. Do not include tool transcripts, chain-of-thought, or process notes.
+- Use the final report shape in `references/subtask-templates.md`.
+
+## Review Standard
+
+- Focus only on security issues introduced by the reviewed change set.
+- Trace attacker input to sensitive sinks such as database queries, shell execution, file access, template rendering, redirects, outbound HTTP, authz gates, token issuance, cache keys, webhook validation, and cross-tenant data filters.
+- Prioritize authorization regressions, trust-boundary mistakes, unsafe execution, unsafe deserialization, file and path handling, token and session flaws, sensitive data leakage, and exploitable client rendering bugs.
+- Treat local-network reachability as potentially high impact when the attacker can still reach the vulnerable surface.
+- Treat Rust as memory-safe by default. Review it for authz, injection, unsafe parsing, crypto misuse, path handling, and logic flaws instead of buffer corruption.
+- Treat React and Angular as safe by default unless the change introduces raw HTML, bypass APIs, unsafe markdown or MDX rendering, `srcdoc`, dangerous URL schemes, or server trust decisions pushed into the client.
+- Consider security-by-design regressions even when they are not classic OWASP checklist items: missing ownership checks, bypassed middleware, unsafe trust in internal headers, weaker tenant scoping, unsafe webhook assumptions, or security-relevant defaults becoming more permissive.
+
+## Constraints
+
+- Do not drift into general correctness, performance, or style review.
+- Do not report unchanged legacy issues except as supporting context for a changed exploit path.
+- Do not report hardening gaps without a concrete exploit path.
+- Treat user-controlled content in AI prompts as out of scope for this skill.
+- Do not write files or make destructive changes while validating a vulnerability.
+
+## Reference Routing
+
+- Read `references/review-playbook.md` during Step 2 for threat-model questions, attack surfaces, and stack-specific heuristics.
+- Read `references/false-positive-filter.md` during Step 4 before validating any candidate.
+- Read `references/subtask-templates.md` before launching sub-tasks and again before formatting the final report.

--- a/plugins/qa/skills/appsec-review/references/false-positive-filter.md
+++ b/plugins/qa/skills/appsec-review/references/false-positive-filter.md
@@ -1,0 +1,104 @@
+# False-Positive Filter
+
+## Contents
+
+- Default posture
+- Hard exclusions
+- Precedents
+- Validation questions
+- Confidence rubric
+- Severity guardrails
+- Validator behavior
+- Final keep or reject rule
+
+## Default Posture
+
+Assume the burden of proof is high. Keep only findings that are clearly exploitable, introduced by the reviewed change set, and meaningful for a security team to act on.
+
+Prefer "no findings" over speculative noise.
+
+## Hard Exclusions
+
+Do not report findings that match these patterns unless there is a concrete, high-confidence exploit path that overrides the exclusion:
+
+1. Denial-of-service, memory exhaustion, CPU exhaustion, or generic resource exhaustion.
+2. Secrets or credentials stored on disk when the claim is only about their presence on disk.
+3. Rate limiting concerns or service overload scenarios.
+4. Non-security validation gaps on ordinary fields without a concrete security consequence.
+5. GitHub Actions sanitization concerns unless untrusted input can clearly reach a dangerous sink.
+6. General hardening gaps or "missing best practice" observations without an exploit path.
+7. Theoretical race conditions or timing attacks without a concrete, practical abuse case.
+8. Outdated third-party dependencies or package versions.
+9. Memory-safety bugs in Rust or other memory-safe languages.
+10. Files that are only tests or only used to run tests.
+11. Log spoofing or log injection by itself.
+12. SSRF claims where the attacker controls only the path and cannot control host or protocol.
+13. Including user-controlled text in AI prompts.
+14. Regex injection and regex DoS.
+15. Documentation-only findings, including markdown files and insecure prose.
+16. Lack of audit logs.
+
+## Precedents
+
+Apply these precedents consistently:
+
+- Logging high-value secrets or PII in plaintext is a vulnerability.
+- Logging non-PII data is not a vulnerability by itself.
+- UUIDs can be treated as unguessable.
+- Environment variables and CLI flags are trusted inputs in normal secure deployments.
+- Resource leaks such as memory leaks or file descriptor leaks are not valid findings here.
+- Subtle web issues such as tabnabbing, XS-Leaks, prototype pollution, and open redirects are usually too weak unless the exploit path is unusually concrete.
+- React and Angular are generally XSS-safe unless the change uses explicitly unsafe rendering paths.
+- Missing client-side permission checks are not a vulnerability unless the server now trusts that client decision.
+- Notebook and shell-script findings need a very specific attacker-controlled path to be valid.
+- MEDIUM findings must still be obvious, concrete, and actionable.
+
+## Validation Questions
+
+Reject a candidate unless each answer is strong:
+
+1. What exact attacker-controlled input exists?
+2. What sensitive sink, policy boundary, or privileged action does that input reach?
+3. Is the vulnerable behavior server-side, security-relevant, and introduced by the reviewed diff?
+4. Is the exploit scenario realistic without assuming control over environment variables, deployment settings, or privileged operators?
+5. Does a framework, library, or nearby guard already neutralize the issue?
+6. Is the finding outside docs-only or test-only code?
+
+## Confidence Rubric
+
+Use this scale:
+
+- `1-3` - weak claim, likely noise
+- `4-6` - suspicious but unproven
+- `7` - plausible, still missing a key proof point
+- `8-9` - strong evidence and a clear exploit path
+- `10` - certain, direct, and difficult to dispute
+
+Keep only findings with confidence `>= 8`.
+
+## Severity Guardrails
+
+- **HIGH** - Directly exploitable auth bypass, tenant escape, RCE, sensitive data exposure, signature bypass, or similar severe impact.
+- **MEDIUM** - Significant security impact that needs some condition or chaining but is still concrete and obvious.
+- **LOW** - Do not report. Treat as noise for this skill.
+
+## Validator Behavior
+
+When validating a candidate:
+
+1. Try to disprove the finding first.
+2. Read the surrounding code to confirm attacker control, sink reachability, and missing safeguards.
+3. Look for framework protections, safe defaults, allowlists, policy layers, and escaping that break the exploit path.
+4. Downgrade or reject the finding if the exploit path depends on unstated assumptions.
+5. Keep the finding only if the remaining argument is concise, concrete, and actionable.
+
+## Final Keep or Reject Rule
+
+Keep a finding only when all of the following are true:
+
+- The issue is in the reviewed change set.
+- The exploit path is concrete.
+- The impact is HIGH or MEDIUM.
+- The confidence score is at least 8.
+
+Otherwise reject it.

--- a/plugins/qa/skills/appsec-review/references/review-playbook.md
+++ b/plugins/qa/skills/appsec-review/references/review-playbook.md
@@ -1,0 +1,178 @@
+# Application Security Review Playbook
+
+## Contents
+
+- Review intent
+- Repository context research
+- High-value attack surfaces
+- Stack-specific heuristics
+- Comparative analysis questions
+- Reporting standard
+
+## Review Intent
+
+Identify newly introduced application-layer vulnerabilities with real exploitation potential. Review only the requested change set and the surrounding code needed to understand it.
+
+Think beyond checklist scanning. Model how an attacker would cross trust boundaries, gain unintended capability, access another tenant's data, or move untrusted input into a sensitive sink.
+
+## Repository Context Research
+
+Start every review by answering these questions:
+
+1. What code paths became reachable or changed privilege?
+2. What inputs are attacker-controlled, partially trusted, or internally trusted?
+3. What guards already exist nearby for auth, tenant scoping, validation, encoding, or safe execution?
+4. Which changed files sit on a trust boundary: controller, API route, webhook, queue consumer, worker, serializer, template, policy layer, data access layer, or client render surface?
+5. What conventions does the repository already use to stay safe, and did the diff bypass them?
+
+Prefer comparative analysis over abstract advice. A new pattern is suspicious when nearby code already uses stricter validation, central auth middleware, a safer serializer, or a safer rendering path.
+
+## High-Value Attack Surfaces
+
+### Input Handling and Injection
+
+Trace user-controlled values into:
+
+- raw SQL, query builders, Mongo selectors, search DSLs
+- shell commands, task runners, OS APIs, template engines
+- filesystem paths, archive extraction paths, storage keys
+- XML parsers, YAML loaders, pickle or similar deserializers
+- code-evaluation surfaces such as `eval`, `exec`, `vm`, dynamic imports, or unsafe template compilation
+
+Ask:
+
+- Can the attacker control structure or only data?
+- Does the framework already parameterize or escape this sink?
+- Did the diff remove validation, canonicalization, or allowlisting?
+
+### Authentication, Authorization, and Multi-Tenancy
+
+Inspect changes for:
+
+- missing ownership checks
+- broader role checks replacing narrower policy checks
+- server-side decisions moved into client code
+- tenant filters removed from queries or caches
+- security middleware bypassed for convenience
+- internal headers, cookies, or route params trusted without verification
+- session or token issuance with weaker claims, scopes, or expiry
+
+Ask:
+
+- Can one authenticated user act on another user's resource?
+- Can a lower-privilege actor trigger an admin-only path?
+- Can cached data or background jobs leak across users or tenants?
+
+### Outbound Requests and Integrations
+
+Inspect:
+
+- webhook signature verification
+- callback URL handling
+- server-to-server requests built from request parameters
+- OAuth or SSO callback validation
+- file fetchers, URL previewers, importers, and image proxies
+
+Ask:
+
+- Can the attacker control the host or protocol, not just the path?
+- Can secrets, tokens, or metadata be sent to an attacker-controlled destination?
+- Did the diff weaken origin, issuer, audience, or signature checks?
+
+### Data Exposure and Sensitive Flows
+
+Inspect:
+
+- logs, analytics, tracing, and telemetry
+- error responses, debug output, stack traces, and verbose exceptions
+- serialization layers, DTOs, GraphQL resolvers, and response mappers
+- client hydration payloads, embedded config, and server-to-client props
+
+Ask:
+
+- Does the change expose secrets, tokens, passwords, PII, or tenant-internal data?
+- Did the diff widen what an endpoint or resolver returns?
+- Does a UI-only change accidentally expose sensitive state in the rendered payload?
+
+### Client Rendering and Design Systems
+
+Treat client code as a security issue only when the change creates a real exploit path. Focus on:
+
+- `dangerouslySetInnerHTML`
+- Angular bypass APIs such as `bypassSecurityTrustHtml`
+- markdown or MDX rendering that allows raw HTML or unsafe link schemes
+- `srcdoc`, sandbox changes, or iframe embedding
+- custom link or rich-text components that stop sanitizing `href`, `src`, or HTML content
+
+Do not report missing client-side permission checks by themselves. Confirm a server-side trust failure or an actual unsafe rendering path first.
+
+## Stack-Specific Heuristics
+
+### TypeScript and Node.js
+
+Look for:
+
+- `child_process`, `exec`, `spawn`, shell interpolation, or wrapper utilities
+- `path.join` or `resolve` on untrusted segments without post-normalization checks
+- raw SQL strings in Prisma, Knex, Sequelize, Drizzle, or direct drivers
+- JWT verification with weak algorithm selection, missing issuer or audience checks, or decode-without-verify flows
+- SSR or API routes passing untrusted URLs into fetchers or proxies
+- unsafe HTML sinks in Next.js, React, Express templating, or markdown renderers
+
+### Python
+
+Look for:
+
+- `subprocess` with shell interpolation
+- `yaml.load`, pickle usage, `eval`, `exec`, or dynamic imports on untrusted data
+- ORM escapes bypassed by raw SQL fragments
+- unsafe Jinja handling, `Markup`, or disabled autoescaping
+- FastAPI, Flask, or Django routes that trust headers, cookies, or ownership claims without verification
+
+### Rust
+
+Do not spend time on impossible memory-safety findings in safe Rust. Focus on:
+
+- authz and tenant-scope regressions
+- raw SQL or string-built queries
+- path traversal and archive extraction paths
+- command execution
+- deserialization and parser trust assumptions
+- crypto misuse, token validation, and signature checks
+- async workflow bugs that expose or mix up another actor's data
+
+### Web and API Design
+
+Check for security-by-design regressions:
+
+- endpoints becoming public when they were previously protected
+- write paths added without ownership or role checks
+- privileged defaults becoming opt-out instead of opt-in
+- admin and user traffic sharing the same identifiers without policy gates
+- cache keys or storage namespaces dropping tenant or user scope
+- internal-only helpers becoming externally reachable through a new route or worker
+
+Also check web-specific controls when the diff changes browser-facing behavior:
+
+- CSRF on state-changing endpoints that rely on cookies, origin checks, or anti-CSRF tokens
+- CORS when credentialed cross-origin access, allowed origins, or exposed headers become broader
+
+## Comparative Analysis Questions
+
+For each changed file, ask:
+
+1. What is the nearest existing secure pattern for the same task?
+2. What validation or authorization step exists elsewhere but not here?
+3. What sensitive sink did the diff move closer to attacker input?
+4. What invariant used to hold that no longer clearly holds?
+
+## Reporting Standard
+
+Raise a finding only when all of the following are true:
+
+- The issue is introduced or exposed by the reviewed change set.
+- The exploit path is specific and plausible.
+- The impact is meaningful enough for a security engineer to raise in PR review.
+- The behavior is not already neutralized by the framework or nearby code.
+
+When uncertain, gather more surrounding code or downgrade to "no finding" instead of stretching the claim.

--- a/plugins/qa/skills/appsec-review/references/subtask-templates.md
+++ b/plugins/qa/skills/appsec-review/references/subtask-templates.md
@@ -1,0 +1,121 @@
+# Sub-Task Templates
+
+## Contents
+
+- Investigator prompt
+- Validator prompt
+- Final report template
+
+## Investigator Prompt
+
+Use this prompt for the first readonly sub-task after collecting the branch or PR context:
+
+```text
+You are a senior application security engineer performing a focused review of the pending changes in this branch.
+
+Review target:
+<target>
+
+Git status:
+<git status output>
+
+Files modified:
+<git diff --name-only output>
+
+Commits:
+<git log --no-decorate output>
+
+Diff content:
+<git diff output>
+
+Task:
+Review the complete change set above. Identify only newly introduced application-layer vulnerabilities with real exploitation potential. This is not a general code review. Ignore pre-existing issues outside the reviewed diff.
+
+Repository context work:
+- Read nearby code for the changed files.
+- Identify existing auth, tenant, validation, sanitization, serialization, templating, and secret-handling patterns.
+- Compare the new code to nearby secure conventions.
+
+Focus areas:
+- auth bypass and privilege escalation
+- broken object- or tenant-level authorization
+- SQL, NoSQL, command, template, and path injection
+- unsafe deserialization and code execution
+- JWT, session, signature, and token validation flaws
+- SSRF when host or protocol control exists
+- CSRF and CORS only when the changed browser-facing behavior creates a concrete exploit path
+- sensitive data exposure in logs, responses, or rendered payloads
+- XSS only when unsafe rendering paths exist
+- security-by-design regressions such as weaker policy gates, unsafe trust in internal headers, weaker tenancy, or webhook verification removal
+
+Out of scope:
+- user-controlled content in AI prompts by itself
+
+Return candidate findings only when there is a concrete exploit path, meaningful impact, and preliminary confidence of at least 7.
+
+Return markdown using this shape:
+
+- `path/to/file:line`
+  - severity: HIGH|MEDIUM
+  - category: <short_category>
+  - confidence: <7-10>
+  - why_exploitable: <one short paragraph>
+  - exploit_scenario: <one short paragraph>
+  - recommendation: <one short paragraph>
+
+Return `No candidate vulnerabilities.` if none.
+```
+
+## Validator Prompt
+
+Use one readonly validator sub-task per candidate. Launch validators in parallel.
+
+```text
+You are validating one candidate vulnerability from an earlier application security review.
+
+Candidate finding:
+<paste one candidate finding here>
+
+Task:
+Challenge this candidate aggressively. Try to disprove it using surrounding code, framework behavior, trust-boundary analysis, validation logic, policy checks, escaping, or other protections. Confirm it only if the exploit path remains concrete after that challenge.
+
+Validation rules:
+- Apply `references/false-positive-filter.md` while validating this candidate.
+- Review only the changed code path and the nearby context needed to understand it.
+- Reject the finding if it depends on speculative attacker control or general best-practice gaps.
+- Reject the finding if the issue is only in docs, tests, client-side trust assumptions, or excluded categories.
+- Keep the finding only if it is introduced by the reviewed diff, still exploitable, and confidence is at least 8.
+- Do not write files or attempt reproduction.
+
+Return markdown using this shape:
+
+- verdict: KEEP|REJECT
+- confidence: <1-10>
+- severity: HIGH|MEDIUM
+- category: <short_category>
+- rationale: <one short paragraph>
+- checked_context: <files or symbols reviewed>
+- recommendation: <one short paragraph if KEEP, otherwise "n/a">
+```
+
+## Final Report Template
+
+Use this final markdown report shape after filtering:
+
+```markdown
+# Vuln 1: <Category>: `path/to/file:line`
+
+* Severity: HIGH
+* Confidence: 9/10
+* Description: <what changed and why it is vulnerable>
+* Exploit Scenario: <how an attacker can abuse it>
+* Recommendation: <specific fix or safer pattern>
+```
+
+If no finding survives, return:
+
+```markdown
+No high-confidence application security findings in the reviewed changes.
+```
+
+Return the markdown report only.

--- a/plugins/qa/skills/code-review/SKILL.md
+++ b/plugins/qa/skills/code-review/SKILL.md
@@ -1,0 +1,106 @@
+---
+name: code-review
+description: Reviews pull requests and code changes for correctness, conventions, maintainability, performance, test coverage, and security. Use when the user asks for a code review, PR review, feedback on a diff, or to check code quality.
+---
+
+# Code Review
+
+Target: `$ARGUMENTS` (optional PR number, branch, path, or diff scope)
+
+## Workflow
+
+Progress checklist:
+
+```
+Code Review:
+- [ ] Step 1: Identify review target
+- [ ] Step 2: Gather change context
+- [ ] Step 3: Evaluate the change
+- [ ] Step 4: Separate findings from noise
+- [ ] Step 5: Deliver findings-first review
+```
+
+### Step 1: Identify Review Target
+
+- If `$ARGUMENTS` is empty and the request is about a PR, run `gh pr list` to show open PRs, then ask the user which PR to review.
+- If `$ARGUMENTS` looks like a PR number, run `gh pr view <number>` to capture the title, status, base branch, head branch, and summary.
+- Otherwise treat the target as local changes, a branch, a commit range, or a file path.
+
+### Step 2: Gather Change Context
+
+- For PR review, run `gh pr diff <number>`.
+- For local review, inspect `git diff`, `git diff --staged`, or the diff for the requested range.
+- Read the changed files with surrounding context. Do not review the raw diff in isolation.
+- Identify the scope: feature, bug fix, refactor, test, docs, or mixed.
+- If `gh` is unavailable or unauthenticated, say so clearly and fall back to the available local diff.
+
+### Step 3: Evaluate the Change
+
+Review for:
+
+- **Correctness** — edge cases, null or empty inputs, error handling, stale state, off-by-one logic, async races, retries, cancellation, and timeouts.
+- **Maintainability** — naming, duplication, single responsibility, magic values, avoidable complexity, and consistency with nearby code.
+- **Performance** — N+1 queries, repeated expensive work, render-loop costs, unnecessary allocations, and over- or under-used memoization.
+- **Type safety** — missing narrowing, unchecked unions, overly broad types, and unclear public API return types.
+- **Testing** — coverage for happy paths, failure paths, and the most likely regression cases.
+- **Security** — auth gaps, injection risks, secret handling, unsafe parsing, XSS, SSRF, or CSRF when relevant.
+
+### Step 4: Separate Findings from Noise
+
+- Flag only issues with real impact on correctness, risk, maintainability, performance, or test confidence.
+- Do not bikeshed on formatting or linter-owned style.
+- Prefer concrete evidence from the diff and surrounding code over speculation.
+- If intent is ambiguous, frame it as a question or risk instead of overstating certainty.
+
+### Step 5: Deliver Findings-First Review
+
+Present findings first, ordered by severity:
+
+- **Must fix** — bugs, security issues, data loss, broken behavior, merge blockers.
+- **Should fix** — maintainability issues, meaningful performance problems, missing tests, or convention drift with real cost.
+- **Nit** — optional minor suggestions.
+
+For each finding include:
+
+- `file`
+- `line` or nearest symbol
+- the issue
+- why it matters
+- a suggested fix
+
+Then include:
+
+1. A short overview of what the change does.
+2. Good decisions worth keeping.
+3. Residual risks or test gaps.
+
+If no actionable findings remain, say so explicitly and mention any remaining uncertainty.
+
+Use this response shape:
+
+```markdown
+## Must fix
+- `path/to/file:line` Issue. Why it matters. Suggested fix.
+
+## Should fix
+- None.
+
+## Nit
+- None.
+
+## Overview
+- Brief summary of the change.
+
+## What looks good
+- Specific strengths.
+
+## Residual risks
+- Missing test coverage, assumptions, or things not verified.
+```
+
+## Constraints
+
+- Findings first. Keep the summary brief.
+- Be constructive and specific.
+- Follow project conventions by reading adjacent code, tests, and config before flagging style issues.
+- Do not invent missing context; say what you verified and what you could not verify.


### PR DESCRIPTION
## Summary
- add `code-review` and `appsec-review` skills to the QA plugin for findings-first review workflows
- document the new QA review capabilities in the plugin README, repository README, and `CLAUDE.md`
- update QA plugin metadata and marketplace metadata to advertise the expanded review scope

## Test plan
- [x] Reviewed `git diff --cached` before committing
- [x] Reviewed `git diff --stat main...HEAD` for the full branch scope
- [ ] Automated tests not run (skills, docs, and metadata changes only)