### PR TITLE
feat(qa): add harness-fixer skill and skill invocation guards

### DIFF
--- a/.claude-plugin/marketplace.json
+++ b/.claude-plugin/marketplace.json
@@ -21,8 +21,8 @@
     },
     {
       "name": "devx-qa",
-      "description": "Quality assurance toolkit to analyze codebases, review code changes, perform focused appsec reviews, audit React patterns, and improve skills",
-      "version": "1.4.0",
+      "description": "Quality assurance toolkit to analyze codebases, review code changes, perform focused appsec reviews, audit React patterns, fix the agentic harness, and improve skills",
+      "version": "1.5.0",
       "author": {
         "name": "Pierre Tomasina",
         "email": "contact@dev3o.com"

--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -54,6 +54,6 @@ Inline bash execution uses `!` syntax: `!`git status``
 | Plugin | Purpose | Commands |
 |--------|---------|----------|
 | devx-git | Git workflow automation | `/commit`, `/pr` (skills) |
-| devx-qa | Architecture analysis, code review, appsec review, skill improvement & React auditing | `/explaining-architecture`, `/code-review`, `/appsec-review`, `/skill-fixer`, `/fixing-react-antipatterns` (skills) |
+| devx-qa | Architecture analysis, code review, appsec review, harness fixing, skill improvement & React auditing | `/explaining-architecture`, `/code-review`, `/appsec-review`, `/fixing-harness`, `/skill-fixer`, `/fixing-react-antipatterns` (skills) |
 | secrets-guard | Block access to secret/sensitive files | hooks only |
 | landing-page | Structured copywriting & Astro 5 landing pages | `/writing-landing-page-copy`, `/building-landing-page` (skills) |

--- a/plugins/qa/.claude-plugin/plugin.json
+++ b/plugins/qa/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "devx-qa",
-  "description": "Quality assurance toolkit to analyze codebases, review code changes, perform focused appsec reviews, audit React patterns, and improve skills",
-  "version": "1.4.0",
+  "description": "Quality assurance toolkit to analyze codebases, review code changes, perform focused appsec reviews, audit React patterns, fix the agentic harness, and improve skills",
+  "version": "1.5.0",
   "author": {
     "name": "Pierre Tomasina",
     "email": "contact@dev3o.com"

--- a/plugins/qa/skills/explaining-architecture/SKILL.md
+++ b/plugins/qa/skills/explaining-architecture/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: explaining-architecture
 description: Analyzes project architecture and generates ASCII state machine and sequence diagrams. Use when the user asks to explain a project, analyze architecture, trace an entrypoint, show a state machine, or generate a sequence diagram.
+disable-model-invocation: true
 ---
 
 # Project Explain

--- a/plugins/qa/skills/explaining-architecture/SKILL.md
+++ b/plugins/qa/skills/explaining-architecture/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: explaining-architecture
-description: Analyzes project architecture and generates ASCII state machine and sequence diagrams. Use when the user asks to explain a project, analyze architecture, trace an entrypoint, show a state machine, or generate a sequence diagram.
+description: Analyzes project architecture and generates ASCII state machine and sequence diagrams. Use for explaining a project, analyzing architecture, tracing an entrypoint, showing a state machine, or generating a sequence diagram.
 disable-model-invocation: true
 ---
 

--- a/plugins/qa/skills/harness-fixer/SKILL.md
+++ b/plugins/qa/skills/harness-fixer/SKILL.md
@@ -1,0 +1,132 @@
+---
+name: fixing-harness
+description: >-
+  Audits a project's agentic harness (CLAUDE.md, AGENTS.md, .claude/rules,
+  .claude/settings.json) and refactors it into a layered, path-scoped
+  configuration that loads only what is relevant. Rewrites CLAUDE.md and
+  AGENTS.md as a thin critical-rules layer, segments domain rules with `paths:`
+  frontmatter, and adds deny-first permission guardrails.
+  Triggers on: fix harness, audit claude.md, refactor agentic configuration,
+  improve agent rules, segment rules by path, review settings.json,
+  harness review, claude.md is too long.
+disable-model-invocation: true
+---
+
+# Fixing the Agentic Harness
+
+Target: `$ARGUMENTS` (optional path; defaults to project root)
+
+## Objective
+
+Refactor the project's harness so the model sees only the rules it needs for the files it touches. CLAUDE.md (and AGENTS.md when present) become a thin always-on critical-rules layer. Domain rules move to `.claude/rules/*.md` with `paths:` frontmatter. Permissions and MCP scope live in `.claude/settings.json` with explicit `deny` guardrails.
+
+The goal is inference weight, not exhaustive documentation: 10 sharp directives the model references in reasoning beat 200 lines it half-skims.
+
+## Workflow
+
+Progress checklist:
+
+```
+Harness Audit & Fix:
+- [ ] Step 1: Inventory current harness
+- [ ] Step 2: Audit against best practices
+- [ ] Step 3: Produce gap analysis
+- [ ] Step 4: Propose refactor plan (confirm with user)
+- [ ] Step 5: Apply changes (CLAUDE.md, AGENTS.md, rules, settings)
+- [ ] Step 6: Verify with /memory
+```
+
+### Step 1: Inventory Current Harness
+
+Read in parallel where present:
+
+- `CLAUDE.md`, `./.claude/CLAUDE.md`, `CLAUDE.local.md`
+- `AGENTS.md` (Codex / Cursor / other agents)
+- `.claude/settings.json`, `.claude/settings.local.json`
+- `.claude/rules/**/*.md` — note `paths:` frontmatter on each
+- `.claude/agents/*.md`, `.claude/skills/*/SKILL.md`
+- `.mcp.json`, `.gitignore`
+
+Capture the actual directory layout (top-level apps, packages, services). Use `tokei` if available, otherwise `find` or `ls`. The layout drives the path scopes proposed in Step 4 — generic globs that don't match real directories are dead weight.
+
+### Step 2: Audit Against Best Practices
+
+Load [references/audit-checklist.md](references/audit-checklist.md) and score each dimension:
+
+1. **CLAUDE.md size and shape** — under 30 lines, directives not prose, no domain dump
+2. **AGENTS.md alignment** — mirrors CLAUDE.md when present, no drift
+3. **Rules segmentation** — path-scoped, one domain per file, no overlap
+4. **Permissions hygiene** — explicit `deny` for destructive ops and secrets, scoped allow patterns, MCP tools narrowed
+5. **Local overrides** — `.claude/settings.local.json` and `CLAUDE.local.md` in `.gitignore`
+6. **Memory ergonomics** — no monolithic root CLAUDE.md drowning monorepo subtrees
+
+### Step 3: Produce Gap Analysis
+
+Output a markdown table:
+
+| Dimension | Status | Severity | Evidence | Suggested fix |
+|-----------|--------|----------|----------|---------------|
+
+Status values: **Respected**, **Violated**, **Partially respected**, **N/A**
+
+Severity values:
+
+- **HIGH** — no `deny` rules, secrets readable, CLAUDE.md > 100 lines, no rules layer in a multi-domain project
+- **MEDIUM** — CLAUDE.md 30–100 lines, rules without path scoping, broad `Bash(*)` allow, AGENTS.md drift
+- **LOW** — stylistic issues, missing nice-to-haves (CLAUDE.local.md, sandbox config)
+
+End with a **Top fixes** list ordered by impact.
+
+### Step 4: Propose Refactor Plan
+
+Present the proposed file layout before writing anything:
+
+```
+CLAUDE.md                       (X lines today -> Y lines after)
+AGENTS.md                       (if other agents are in use)
+.claude/rules/
+├── <domain-1>.md   paths: <glob>
+├── <domain-2>.md   paths: <glob>
+└── ...
+.claude/settings.json           (deny rules + scoped allow)
+.gitignore                      (add .claude/*.local.*, CLAUDE.local.md)
+```
+
+Confirm with the user before applying. Path scopes must match real directories surfaced in Step 1.
+
+### Step 5: Apply Changes
+
+For each file:
+
+1. **Rewrite CLAUDE.md** using [references/claude-md-template.md](references/claude-md-template.md). Keep only project-wide directives. Move domain-specific content to rules files. Target under 30 lines.
+
+2. **Sync AGENTS.md** using [references/agents-md-template.md](references/agents-md-template.md) when other agents are in use. Mirror the critical rules; reference domain rules by path rather than duplicating them.
+
+3. **Create path-scoped rules** in `.claude/rules/<domain>.md` using patterns from [references/path-scoping-patterns.md](references/path-scoping-patterns.md). Each rule file has `paths:` frontmatter listing globs and contains only directives that apply inside those paths.
+
+4. **Harden `.claude/settings.json`** using [references/settings-recipes.md](references/settings-recipes.md). Add `deny` for destructive ops and secret files. Tighten allow patterns. Scope MCP tools.
+
+5. **Update `.gitignore`** to include `.claude/*.local.*` and `CLAUDE.local.md` if missing.
+
+Preserve concrete content the user relies on — package manager command, lint command, framework gates. Surface anything you plan to delete before deleting it.
+
+### Step 6: Verify
+
+Validate the rewrite, then fix anything that fails and re-verify:
+
+1. **Line budget** — `wc -l CLAUDE.md` should be under 30. If not, return to Step 5 and move more content into rules.
+2. **Path scope sanity** — for each new rules file, confirm at least one file in the repo matches its `paths:` glob (`git ls-files | grep -E <pattern>`). If zero matches, the glob is wrong.
+3. **Deny rules in place** — `grep -c '"deny"' .claude/settings.json` should return ≥ 1. The deny list must include destructive ops and secret reads.
+4. **`.gitignore` covers locals** — `grep -E '\.claude/\*\.local|CLAUDE\.local\.md' .gitignore` should return matches.
+5. **Memory check** — ask the user to run `/memory` and confirm CLAUDE.md plus only the path-scoped rules relevant to the current cwd are listed as loaded.
+
+If any check fails, fix it and re-run from check 1. Do not declare the refactor complete with a failing check.
+
+## Constraints
+
+- Do not delete existing rules the user has not approved removing — move to rules files instead
+- Do not invent project conventions; only restructure what is already documented
+- Preserve concrete commands (lint, package manager, framework codegen) from the original CLAUDE.md
+- When a rule is borderline domain-specific, prefer the rules layer — promotion to CLAUDE.md should be earned, not assumed
+- If the project has no `.claude/` directory yet, create it; do not assume team policies the user has not stated
+- Never weaken a deny rule without explicit user approval

--- a/plugins/qa/skills/harness-fixer/SKILL.md
+++ b/plugins/qa/skills/harness-fixer/SKILL.md
@@ -6,9 +6,9 @@ description: >-
   configuration that loads only what is relevant. Rewrites CLAUDE.md and
   AGENTS.md as a thin critical-rules layer, segments domain rules with `paths:`
   frontmatter, and adds deny-first permission guardrails.
-  Triggers on: fix harness, audit claude.md, refactor agentic configuration,
-  improve agent rules, segment rules by path, review settings.json,
-  harness review, claude.md is too long.
+  Use for: fixing the harness, auditing claude.md, refactoring agentic
+  configuration, improving agent rules, segmenting rules by path,
+  reviewing settings.json, harness review, or when claude.md is too long.
 disable-model-invocation: true
 ---
 

--- a/plugins/qa/skills/harness-fixer/references/agents-md-template.md
+++ b/plugins/qa/skills/harness-fixer/references/agents-md-template.md
@@ -1,0 +1,51 @@
+# AGENTS.md Template
+
+AGENTS.md is read by non-Claude agents (Codex, Cursor, others). Keep it aligned with CLAUDE.md — drift here means different tools enforce different rules on the same codebase.
+
+## Skeleton
+
+```markdown
+# Agent Instructions
+
+This file applies to non-Claude-Code agents. For Claude Code, see `CLAUDE.md` and `.claude/rules/`.
+
+## Project Shape
+<same project shape as CLAUDE.md>
+
+## Critical Rules
+<same numbered list as CLAUDE.md>
+
+## Domain Rules
+
+For domain-specific conventions, see:
+
+- `apps/web/**` — frontend conventions in `.claude/rules/frontend.md`
+- `packages/backend/**` — backend conventions in `.claude/rules/backend.md`
+- `packages/backend/src/**`, `apps/web/src/**` — security model in `.claude/rules/security.md`
+
+Agents that cannot load `.claude/rules/` automatically should inline the relevant rule file before working in those paths.
+```
+
+## Sync Discipline
+
+When a rule is promoted to CLAUDE.md, update AGENTS.md in the same change. The two files form the always-on critical-rules layer for the project — drift between them creates inconsistent behavior across tools.
+
+## When AGENTS.md Is Not Needed
+
+If the project is Claude-only and no teammate uses another agent, skip AGENTS.md. Adding it creates a maintenance burden without a consumer.
+
+## When AGENTS.md Diverges from CLAUDE.md
+
+A few tool-specific notes are legitimate (different file path conventions, different invocation syntax). Mark them clearly:
+
+```markdown
+## Tool-Specific Notes
+
+### Codex
+- <note>
+
+### Cursor
+- <note>
+```
+
+Keep this section minimal. Universal rules stay in the main numbered list — duplicating them tool-by-tool is the path to drift.

--- a/plugins/qa/skills/harness-fixer/references/audit-checklist.md
+++ b/plugins/qa/skills/harness-fixer/references/audit-checklist.md
@@ -1,0 +1,79 @@
+# Harness Audit Checklist
+
+Use this checklist during Step 2 of the workflow. Gather evidence from the files inventoried in Step 1 and score each dimension.
+
+## 1. CLAUDE.md size and shape
+
+| Check | Target | Failure signal |
+|-------|--------|----------------|
+| Line count | < 30 lines | > 100 lines = HIGH; 30–100 = MEDIUM |
+| Tone | Imperative directives ("Use X", "Run Y", "Never Z") | Descriptive prose ("We use X because…") = MEDIUM |
+| Scope | Project-wide rules only | Domain-specific sections (frontend-only, backend-only) = MEDIUM |
+| Buried critical rules | Top of file | "Critical Rules" section near the bottom = MEDIUM |
+| Architecture dumps | Not present | Full dependency lists, full directory trees = HIGH |
+| Stale content | None | References to tools or files no longer in the repo = MEDIUM |
+| Concrete commands | Present (lint, test, package manager) | Vague ("run the build") = LOW |
+
+CLAUDE.md loads as a user message and competes with conversation context for attention. Brevity is what makes the model reference it in reasoning.
+
+## 2. AGENTS.md alignment
+
+Apply only when the project supports Codex, Cursor, or other non-Claude agents.
+
+| Check | Target | Failure signal |
+|-------|--------|----------------|
+| Drift from CLAUDE.md | Critical rules identical | Rules disagree between files = HIGH |
+| Domain rules duplicated | Referenced by path, not inlined | Duplicates full rule text from `.claude/rules/` = MEDIUM |
+| Tool-specific notes | Clearly marked | Mixed with universal rules = LOW |
+| Existence when other agents are used | Present | Missing while teammates use Codex/Cursor = MEDIUM |
+| Existence when only Claude is used | Absent (or minimal) | Unused AGENTS.md adds maintenance cost = LOW |
+
+## 3. Rules segmentation
+
+| Check | Target | Failure signal |
+|-------|--------|----------------|
+| `.claude/rules/` exists | Yes when project has multiple domains | Missing in monorepo / multi-stack = HIGH |
+| `paths:` frontmatter | Present on domain-specific rules | All rules load globally = MEDIUM |
+| Path scope matches code layout | Yes | Generic globs that match nothing or everything = MEDIUM |
+| Single domain per file | Yes | One file covers frontend + backend + security = MEDIUM |
+| Overlap with CLAUDE.md | None | Rules restate CLAUDE.md content = LOW |
+| File length | < 60 lines per rule | Sprawling files indicate a missed split = LOW |
+
+The rule of thumb: if the model is editing file X, exactly one rules file (or two non-overlapping ones) should fire.
+
+## 4. Permissions hygiene
+
+| Check | Target | Failure signal |
+|-------|--------|----------------|
+| `deny` rules present | Destructive ops + secrets denied | Missing `Bash(git push *)`, `Bash(rm -rf *)`, `Read(./.env)` = HIGH |
+| Secret files denied | `.env`, `.env.*`, credential paths | Readable = HIGH |
+| Allow patterns scoped | `Bash(bun:*)`, `Bash(git status:*)` | `Bash(*)` = HIGH |
+| MCP tools scoped | `mcp__server__specific_tool` | Broad `mcp__server__*` for risky servers = MEDIUM |
+| Permission mode | `dontAsk` once allowlist is mature | `default` with mature allowlist = LOW (just efficiency) |
+| Publish commands denied | Yes | `npm publish`, `cargo publish`, etc. allowed = HIGH |
+
+`deny` always wins — even `bypassPermissions` mode respects it. That makes deny rules the hard safety layer.
+
+## 5. Local overrides
+
+| Check | Target | Failure signal |
+|-------|--------|----------------|
+| `.gitignore` includes `.claude/*.local.*` | Yes | Missing = HIGH (personal config will leak) |
+| `CLAUDE.local.md` in `.gitignore` | Yes (if used) | Missing = HIGH |
+| Personal vs team split | `settings.json` = team, `settings.local.json` = personal | Personal MCP servers committed = MEDIUM |
+| Credentials in MCP config | Environment refs only | Hardcoded secrets = HIGH |
+
+## 6. Memory ergonomics
+
+| Check | Target | Failure signal |
+|-------|--------|----------------|
+| Monorepo subtree CLAUDE.md | Present in distinct packages | Single root CLAUDE.md tries to cover all subtrees = MEDIUM |
+| `claudeMdExcludes` | Configured if monorepo has unrelated teams' rules | Missing in large monorepo = LOW |
+| Auto-memory pollution | Not in repo | Auto-memory files committed = MEDIUM |
+| Skills / agents location | Under `.claude/skills/` or `.claude/agents/` | Workflow content stuffed in CLAUDE.md = MEDIUM |
+
+## Severity glossary
+
+- **HIGH** — active risk: security gap, autonomy blocker, leaked credentials, secrets readable
+- **MEDIUM** — quality issue: drift between files, wasted context, ambiguous scopes
+- **LOW** — stylistic or efficiency tuning

--- a/plugins/qa/skills/harness-fixer/references/claude-md-template.md
+++ b/plugins/qa/skills/harness-fixer/references/claude-md-template.md
@@ -1,0 +1,57 @@
+# CLAUDE.md Template
+
+Use this as the skeleton when rewriting CLAUDE.md. Target under 30 lines.
+
+## Skeleton
+
+```markdown
+## Project Shape
+- <one line per top-level package or app, with what it is and the framework>
+- <how packages reference each other — e.g. `@org/backend` for backend imports>
+- <where to run framework CLIs from (shadcn from apps/web, etc.)>
+
+## Critical Rules
+1. <package manager and how to install (e.g. "Use `bun`, never `npm` or `yarn`")>
+2. <project-wide language conventions (e.g. "No semicolons in TypeScript")>
+3. <lint command + when to run it ("Run `bun run lint` before completing work")>
+4. <framework codegen gate ("Run `bunx convex dev --once` after any packages/backend/src/convex/** change")>
+5. <git conventions ("Use `git mv` for file moves to preserve history")>
+6. <UI / icon library if a strong preference exists>
+7. <verification loop for UI changes — Playwright MCP, screenshot, etc.>
+8. <official docs the agent must consult ("Always refer to official docs for X, never assume")>
+```
+
+Numbered rules read more weight in the model's reasoning than bulleted prose.
+
+## What Goes Here vs. Rules
+
+| Belongs in CLAUDE.md | Move to `.claude/rules/<domain>.md` |
+|----------------------|-------------------------------------|
+| Package manager command | Backend module naming patterns |
+| Lint command + when to run | Frontend component conventions |
+| Universal type rules | Security model per layer |
+| Architectural top-level layout | Database migration patterns |
+| Critical workflow gates (codegen, schema) | Test layout per domain |
+| Hard safety rules | API endpoint conventions |
+
+## Voice
+
+- Imperative: "Use X", "Run Y", "Never Z"
+- No prose explaining *why* unless it prevents a known footgun
+- Numbered list for rules — easier for the model to reference
+- File paths and exact commands beat descriptions
+
+## Length Discipline
+
+If a rule will not fit while staying under 30 lines, it almost certainly belongs in a rules file. The rare exception is a hard safety rule (e.g. "Never modify migrations on `main`") which earns its place regardless of budget.
+
+## The Promotion Pattern
+
+Rules do not start in CLAUDE.md — they earn their way there:
+
+1. A footgun bites you during a session
+2. You add it to the relevant `.claude/rules/` file
+3. It keeps recurring across different contexts
+4. After three repeats, promote it to CLAUDE.md Critical Rules
+
+When in doubt, leave it in the rules layer. CLAUDE.md should only hold battle-tested, project-wide directives.

--- a/plugins/qa/skills/harness-fixer/references/path-scoping-patterns.md
+++ b/plugins/qa/skills/harness-fixer/references/path-scoping-patterns.md
@@ -1,0 +1,138 @@
+# Path Scoping Patterns
+
+Rules in `.claude/rules/*.md` can include a `paths:` frontmatter to load only when matching files are read or edited.
+
+## Contents
+
+- Frontmatter Shape
+- Common Patterns (frontend, backend, db, tests, security, infra, Python, Rust)
+- One Domain Per File
+- Verifying Scopes
+- Symlinks for Cross-Project Standards
+- Frontmatter Tips
+
+## Frontmatter Shape
+
+```yaml
+---
+paths:
+  - <glob>
+  - <glob>
+---
+```
+
+Rules with `paths:` load on demand. Rules without `paths:` load at session start (treat them like CLAUDE.md — use sparingly).
+
+## Common Patterns
+
+### Frontend (web / mobile)
+
+```yaml
+paths:
+  - apps/web/**
+  - packages/ui/**
+  - "**/*.tsx"
+```
+
+### Backend / API
+
+```yaml
+paths:
+  - packages/backend/**
+  - services/api/**
+  - "**/*_api.ts"
+```
+
+### Database / migrations
+
+```yaml
+paths:
+  - prisma/migrations/**
+  - db/migrations/**
+  - "**/*.sql"
+  - convex.json
+```
+
+### Tests
+
+```yaml
+paths:
+  - "**/*.test.ts"
+  - "**/*.spec.ts"
+  - tests/**
+  - e2e/**
+```
+
+### Security-sensitive
+
+```yaml
+paths:
+  - packages/backend/src/auth/**
+  - apps/web/src/auth/**
+  - "**/middleware/**"
+  - "**/permissions/**"
+```
+
+### Infrastructure / CI
+
+```yaml
+paths:
+  - .github/**
+  - terraform/**
+  - "**/Dockerfile"
+  - "**/docker-compose*.yml"
+```
+
+### Python services
+
+```yaml
+paths:
+  - services/*/src/**
+  - "**/*.py"
+  - pyproject.toml
+```
+
+### Rust crates
+
+```yaml
+paths:
+  - crates/*/src/**
+  - "**/Cargo.toml"
+```
+
+## One Domain Per File
+
+Each rule file should answer one question: "What do I do when editing X?"
+
+| Good split | Bad split |
+|------------|-----------|
+| `frontend.md`, `backend.md`, `security.md` | `conventions.md` covering everything |
+| `convex.md` (scoped to Convex backend) | `db.md` covering Convex + Postgres + Redis |
+| `auth.md` for both client and server auth flows | `auth-client.md` and `auth-server.md` for the same model |
+| `migrations.md` for schema changes only | `data.md` mixing migrations + queries + caching |
+
+## Verifying Scopes
+
+After writing rules:
+
+1. Open a file inside the intended scope and run `/memory` — confirm the rule loaded
+2. Open a file *outside* the scope and confirm it did **not** load
+3. If the rule loads everywhere, the path scope is too broad
+4. If the rule never loads, the glob does not match real files
+
+## Symlinks for Cross-Project Standards
+
+Maintain shared rules centrally and symlink into each project:
+
+```bash
+ln -s ~/company-standards/security.md .claude/rules/security.md
+```
+
+The symlink loads like a normal rule file. Updates to the central file propagate to every project.
+
+## Frontmatter Tips
+
+- Use absolute-from-root globs (`apps/web/**`) — relative paths inside frontmatter are confusing
+- Quote globs that start with `*` or contain special characters
+- Keep the `paths:` list short — three to five globs is usually enough
+- If you need more than five globs, the rule is probably trying to cover two domains

--- a/plugins/qa/skills/harness-fixer/references/settings-recipes.md
+++ b/plugins/qa/skills/harness-fixer/references/settings-recipes.md
@@ -1,0 +1,227 @@
+# Settings Recipes
+
+Drop-in `.claude/settings.json` patterns by stack. Always combine `allow` with `deny` — `allow` without `deny` is an open door, and `deny` always wins (even in `bypassPermissions` mode).
+
+## Contents
+
+- Minimum Viable `deny`
+- Stack recipes: Node / bun, Python (uv / poetry), Rust (cargo), Go
+- MCP Scoping
+- Pattern Reminders (wildcard syntax)
+- `.claude/settings.local.json` Is Personal
+- Permission Mode (`dontAsk`)
+- Sandbox (macOS / Linux)
+
+## Minimum Viable `deny`
+
+Every project should deny at least these:
+
+```json
+{
+  "permissions": {
+    "deny": [
+      "Bash(git push:*)",
+      "Bash(git push)",
+      "Bash(rm -rf:*)",
+      "Bash(rm -rf *)",
+      "Bash(sudo:*)",
+      "Read(./.env)",
+      "Read(./.env.*)",
+      "Read(**/credentials*)",
+      "Read(**/secrets/**)"
+    ]
+  }
+}
+```
+
+## Node / TypeScript (bun)
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(bun:*)",
+      "Bash(bunx:*)",
+      "Bash(npm run lint)",
+      "Bash(npm test)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git log:*)",
+      "Bash(git add:*)",
+      "Bash(git commit:*)",
+      "Bash(gh pr:*)",
+      "Bash(gh issue:*)"
+    ],
+    "deny": [
+      "Bash(bun publish:*)",
+      "Bash(npm publish:*)",
+      "Bash(git push:*)",
+      "Bash(rm -rf:*)",
+      "Read(./.env)",
+      "Read(./.env.*)"
+    ]
+  }
+}
+```
+
+## Python (uv / poetry)
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(uv:*)",
+      "Bash(poetry:*)",
+      "Bash(pytest:*)",
+      "Bash(ruff:*)",
+      "Bash(mypy:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git commit:*)"
+    ],
+    "deny": [
+      "Bash(uv publish:*)",
+      "Bash(poetry publish:*)",
+      "Bash(twine upload:*)",
+      "Bash(git push:*)",
+      "Bash(rm -rf:*)",
+      "Read(./.env)",
+      "Read(**/credentials*)"
+    ]
+  }
+}
+```
+
+## Rust (cargo)
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(cargo:*)",
+      "Bash(rustfmt:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git commit:*)"
+    ],
+    "deny": [
+      "Bash(cargo publish:*)",
+      "Bash(git push:*)",
+      "Bash(rm -rf:*)",
+      "Read(./.env)"
+    ]
+  }
+}
+```
+
+## Go
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "Bash(go:*)",
+      "Bash(gofmt:*)",
+      "Bash(golangci-lint:*)",
+      "Bash(git status:*)",
+      "Bash(git diff:*)",
+      "Bash(git commit:*)"
+    ],
+    "deny": [
+      "Bash(git push:*)",
+      "Bash(rm -rf:*)",
+      "Read(./.env)"
+    ]
+  }
+}
+```
+
+## MCP Scoping
+
+Prefer specific tools over server wildcards:
+
+```json
+{
+  "permissions": {
+    "allow": [
+      "mcp__playwright__browser_navigate",
+      "mcp__playwright__browser_snapshot",
+      "mcp__playwright__browser_console_messages",
+      "mcp__convex__status",
+      "mcp__convex__runOneoffQuery"
+    ]
+  }
+}
+```
+
+Allow broad `mcp__server__*` only after running the workflow once and confirming the server's full tool surface is acceptable.
+
+## Pattern Reminders
+
+| Pattern | Matches | Note |
+|---------|---------|------|
+| `Bash(bun *)` | `bun test`, `bun run lint` | Space before `*` = word boundary |
+| `Bash(bun*)` | `bun test`, `bunx` | No space = prefix match (looser) |
+| `Bash(git commit *)` | `git commit -m "..."` | Scoped to one subcommand |
+| `mcp__playwright__*` | All Playwright MCP tools | Server-level wildcard |
+| `WebFetch(domain:docs.x.com)` | Fetch from one host | Domain-scoped |
+| `Read(./.env.*)` | `.env.local`, `.env.prod` | Single-segment glob |
+| `Read(**/secrets/**)` | Any path containing `secrets/` | Recursive glob |
+
+## `.claude/settings.local.json` Is Personal
+
+Never commit. Use it for:
+
+```json
+{
+  "env": {
+    "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
+  },
+  "permissions": {
+    "allow": [
+      "WebFetch(domain:internal.mycorp.com)",
+      "Bash(my-personal-script:*)"
+    ]
+  }
+}
+```
+
+Required `.gitignore` entries:
+
+```
+.claude/*.local.*
+CLAUDE.local.md
+```
+
+## Permission Mode
+
+After the allowlist is mature, switch to `dontAsk` so the agent stops prompting for anything not explicitly approved:
+
+```json
+{
+  "permissions": {
+    "defaultMode": "dontAsk"
+  }
+}
+```
+
+`dontAsk` + complete allowlist + deny rules = a fully autonomous agent within declared boundaries. Until the allowlist is stable, leave it at `default`.
+
+## Sandbox (macOS / Linux)
+
+For long autonomous loops, enable the OS-level sandbox:
+
+```json
+{
+  "sandbox": {
+    "enabled": true,
+    "autoAllowBashIfSandboxed": true,
+    "network": {
+      "allowLocalBinding": true,
+      "allowUnixSockets": ["~/.gnupg/S.gpg-agent"]
+    }
+  }
+}
+```
+
+The sandbox protects against Claude making mistakes during agentic flows. It does **not** protect against malicious code (npm postinstall, supply chain) — use dev containers for that threat model.

--- a/plugins/qa/skills/skill-fixer/SKILL.md
+++ b/plugins/qa/skills/skill-fixer/SKILL.md
@@ -1,6 +1,7 @@
 ---
 name: fixing-skills
 description: Evaluate and improve a plugin's skills by applying Anthropic's skill authoring best practices. Triggers when the user asks to fix, improve, or review skills for a specific plugin or agent team.
+disable-model-invocation: true
 ---
 
 You are aware of softmax distribute attention.

--- a/plugins/qa/skills/skill-fixer/SKILL.md
+++ b/plugins/qa/skills/skill-fixer/SKILL.md
@@ -1,6 +1,6 @@
 ---
 name: fixing-skills
-description: Evaluate and improve a plugin's skills by applying Anthropic's skill authoring best practices. Triggers when the user asks to fix, improve, or review skills for a specific plugin or agent team.
+description: Evaluate and improve a plugin's skills by applying Anthropic's skill authoring best practices. Use to fix, improve, or review skills for a specific plugin or agent team.
 disable-model-invocation: true
 ---
 


### PR DESCRIPTION
## Summary
- Adds `/fixing-harness` to devx-qa (v1.5.0) — audits CLAUDE.md, AGENTS.md, `.claude/rules`, and `.claude/settings.json` then refactors the harness into a layered, path-scoped configuration with deny-first permission guardrails
- Guards `explaining-architecture` and `skill-fixer` with `disable-model-invocation: true` so they only run on explicit user invocation (not auto-triggered by Claude)

## Test plan
- [x] Install devx-qa from the marketplace and verify `/fixing-harness` appears in `/help`
- [x] Run `/fixing-harness` on a project with a bloated CLAUDE.md and confirm it produces a gap analysis table, proposes a file layout, and waits for confirmation before writing
- [x] Verify Step 6 checks pass: `wc -l CLAUDE.md` < 30, deny rules present in settings.json, `.gitignore` covers local files
- [x] Confirm `/explaining-architecture` and `/skill-fixer` no longer auto-trigger without explicit user invocation