### PR TITLE
feat(devx-git): add rebase skill with backup and conflict resolution

### DIFF
--- a/.claude/CLAUDE.md
+++ b/.claude/CLAUDE.md
@@ -53,7 +53,7 @@ Inline bash execution uses `!` syntax: `!`git status``
 
 | Plugin | Purpose | Commands |
 |--------|---------|----------|
-| devx-git | Git workflow automation | `/commit`, `/pr` (skills) |
+| devx-git | Git workflow automation | `/commit`, `/pr`, `/rebase` (skills) |
 | devx-qa | Architecture analysis, code review, appsec review, harness fixing, skill improvement & React auditing | `/explaining-architecture`, `/code-review`, `/appsec-review`, `/fixing-harness`, `/skill-fixer`, `/fixing-react-antipatterns` (skills) |
 | secrets-guard | Block access to secret/sensitive files | hooks only |
 | landing-page | Structured copywriting & Astro 5 landing pages | `/writing-landing-page-copy`, `/building-landing-page` (skills) |

--- a/plugins/git/.claude-plugin/plugin.json
+++ b/plugins/git/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "devx-git",
-  "description": "Streamline your git workflow with simple commands for committing, pushing, and creating pull requests",
-  "version": "2.0.0",
+  "description": "Streamline your git workflow with simple commands for committing, creating pull requests, and updating branches via rebase",
+  "version": "2.1.0",
   "author": {
     "name": "Pierre Tomasina",
     "email": "contact@dev3o.com"

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -51,6 +51,26 @@ Create GitHub pull requests with proper descriptions. Defaults to `main`.
 
 ---
 
+### `/devx-git:rebase [origin-branch]`
+
+Update the current branch with an origin branch via rebase, with safe conflict resolution and automatic backup/recovery. Defaults to `main`.
+
+```
+/devx-git:rebase
+/devx-git:rebase develop
+```
+
+**What happens:**
+1. Requires a clean working tree (stops otherwise)
+2. Creates a backup branch of your current branch
+3. Rebases onto the origin branch (`git pull --rebase`)
+4. On conflict, triages whether to resolve in place or abort to a single merge based on how many commits remain
+5. Resolves conflicts by reconciling both sides — asks only on genuinely risky contradictions
+6. Offers a `--force-with-lease` push (rebase rewrites history) — only runs it if you confirm
+7. Deletes the backup automatically when safe; keeps it (with restore instructions) if anything went wrong
+
+---
+
 ## GPG Signed Commits (macOS Sandbox)
 
 If you use GPG commit signing with Claude Code's sandbox mode, GPG needs access to its Unix socket. Add this to your `~/.claude/settings.json`:

--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -66,7 +66,7 @@ Update the current branch with an origin branch via rebase, with safe conflict r
 3. Rebases onto the origin branch (`git pull --rebase`)
 4. On conflict, triages whether to resolve in place or abort to a single merge based on how many commits remain
 5. Resolves conflicts by reconciling both sides — asks only on genuinely risky contradictions
-6. Offers a `--force-with-lease` push (rebase rewrites history) — only runs it if you confirm
+6. Offers a push — `--force-with-lease` on the rebase path, a plain fast-forward after the merge fallback — only if you confirm
 7. Deletes the backup automatically when safe; keeps it (with restore instructions) if anything went wrong
 
 ---

--- a/plugins/git/skills/rebase/SKILL.md
+++ b/plugins/git/skills/rebase/SKILL.md
@@ -1,0 +1,71 @@
+---
+name: rebase
+description: Updates the current branch onto an origin branch via rebase, with a recoverable backup, safe conflict resolution, and recovery steps. Use when the user runs /rebase or asks to rebase/update their branch onto main (or another origin branch).
+disable-model-invocation: true
+allowed-tools: Bash(git:*), Read, Edit, Grep, Glob
+argument-hint: "[origin-branch]"
+---
+
+# Update Branch With Origin
+
+Rebase the current branch onto `<origin-branch>` (= `$ARGUMENTS`, default `main`), always behind a recoverable backup.
+
+Copy this checklist into your reply and check items off as you go:
+
+```
+Rebase Progress:
+- [ ] Preflight passed (clean tree, not detached, branch ≠ origin)
+- [ ] Backup branch created
+- [ ] Rebase attempted
+- [ ] Conflicts triaged + resolved (or merged as fallback)
+- [ ] Result verified clean
+- [ ] Force-with-lease push (only if user confirmed)
+- [ ] Backup deleted (success) or kept (recovery)
+```
+
+## Guardrails (exact — do not vary)
+
+1. **The working tree MUST be clean.** Run `git status --porcelain`; any output → stop and tell the user to commit or stash first. Do nothing else.
+2. Stop if HEAD is detached or the current branch equals `<origin-branch>`.
+3. **Back up before touching anything:** `git branch backup/$(git branch --show-current)-$(git rev-parse --short HEAD)`. Tell the user the exact name; call it `<backup>` below.
+4. Never delete `<backup>` unless the final tree is verified clean and the update succeeded.
+5. Never force-push without explicit user confirmation.
+
+## Phase 1 — Rebase
+
+`git fetch origin`, then `git pull --rebase origin <origin-branch>`.
+- No conflict → Phase 4.
+- Conflict → Phase 2.
+
+## Phase 2 — Triage: resolve or abort
+
+Inspect commits left to replay and the conflict shape (`git status`). State the decision and why before proceeding.
+- **≤5 commits, mechanical conflicts** → resolve in place (Phase 3).
+- **>5 commits, the same files re-conflicting across commits, or sprawling/risky** → `git rebase --abort`, then `git merge origin/<origin-branch>` and resolve the whole set at once (Phase 3 rules, single commit).
+
+## Phase 3 — Resolve
+
+Per conflict, **default to keeping both sides** — reconcile the origin and local changes so neither intent is lost. Then `git add` the resolved files and `git rebase --continue`; repeat until done.
+
+**Reconcile silently** (do NOT ask) for ordinary, combinable conflicts:
+- Both sides added different imports, functions, or non-overlapping list entries → keep both.
+- Both edited nearby lines with compatible intent → merge the edits.
+
+**Ask the user** only when the sides genuinely contradict and "keep both" is wrong:
+- The same key/value set to two incompatible things.
+- One side deletes a file the other side substantively edits.
+- Conflicting schema, migration, or lockfile ordering.
+
+Present the specific conflict and concrete options. If resolution becomes unworkable, `git rebase --abort` and take the merge fallback in Phase 2.
+
+## Phase 4 — Finish
+
+1. **Verify the result:** `git status` clean, `git log --oneline -5` correct. If it is not clean, do not proceed — go to recovery (step 4).
+2. The branch now diverges from its remote. **Offer** `git push --force-with-lease`; run it only if the user confirms.
+3. **Success** → delete the backup: `git branch -D <backup>`.
+4. **Anything wrong** → keep `<backup>` and give recovery steps:
+   ```bash
+   git rebase --abort 2>/dev/null; git merge --abort 2>/dev/null
+   git reset --hard <backup>
+   ```
+5. Summarize: rebase vs. merge path, conflicts resolved, push status, and whether the backup was deleted or kept.

--- a/plugins/git/skills/rebase/SKILL.md
+++ b/plugins/git/skills/rebase/SKILL.md
@@ -61,7 +61,9 @@ Present the specific conflict and concrete options. If resolution becomes unwork
 ## Phase 4 — Finish
 
 1. **Verify the result:** `git status` clean, `git log --oneline -5` correct. If it is not clean, do not proceed — go to recovery (step 4).
-2. The branch now diverges from its remote. **Offer** `git push --force-with-lease`; run it only if the user confirms.
+2. Update the remote (offer only; run it solely on user confirmation):
+   - **Rebase path** (history rewritten) → `git push --force-with-lease`.
+   - **Merge-fallback path** (Phase 2 abort) → history was not rewritten, so a plain `git push` fast-forwards; force is unnecessary.
 3. **Success** → delete the backup: `git branch -D <backup>`.
 4. **Anything wrong** → keep `<backup>` and give recovery steps:
    ```bash


### PR DESCRIPTION
## Summary
- Adds a safe `/devx-git:rebase [origin-branch]` skill that always creates a recoverable backup branch before touching history, so there is no risk of losing work during a rebase gone wrong
- Defaults to `git pull --rebase`, falls back to `git merge` when commit count or conflict shape makes per-commit resolution risky, and offers `--force-with-lease` push only on explicit confirmation — preventing accidental remote history rewrites
- Conflict resolution defaults to reconciling both sides silently; escalates to the user only for genuine contradictions (incompatible values, delete-vs-edit, schema/lockfile conflicts)

## Test plan
- [x] Run `/devx-git:rebase` on a dirty working tree — should stop immediately with instructions to commit/stash
- [x] Run on a clean branch with no conflicts — should rebase, verify, offer push, delete backup on confirmation
- [x] Run on a branch with ≤5 mechanical conflicts — should resolve silently and continue
- [x] Run on a branch with >5 commits to replay or sprawling conflicts — should abort and fall back to merge
- [x] Simulate a failed resolution mid-rebase — verify backup branch is kept and recovery steps are printed
- [x] Verify `plugin.json` version reads `2.1.0`