### PR TITLE
fix(devx-git): make ci skill autonomous with session-aware selective staging

### DIFF
--- a/plugins/git/README.md
+++ b/plugins/git/README.md
@@ -12,17 +12,17 @@ Git workflow automation for developers who commit often and want clean history.
 
 ### `/devx-git:ci`
 
-Conventional commits from staged changes. No more thinking about commit message format.
+Autonomous conventional commits. Picks out this session's work, skips junk and secrets, and commits — no manual staging, no thinking about commit message format.
 
 ```
 /devx-git:ci
 ```
 
 **What happens:**
-1. Analyzes your staged diff
-2. Determines type (`feat`, `fix`, `refactor`, etc.), scope, and subject
-3. Shows preview for your confirmation
-4. Commits
+1. Surveys the working tree and sorts changes: this session's work vs. junk, secrets, and unrelated edits
+2. Stages only the session's work with explicit paths (never `git add -A`)
+3. Determines type (`feat`, `fix`, `refactor`, etc.), scope, and subject
+4. Commits immediately, then reports anything it left out (and why)
 
 **Output:**
 ```

--- a/plugins/git/skills/ci/SKILL.md
+++ b/plugins/git/skills/ci/SKILL.md
@@ -1,40 +1,78 @@
 ---
 name: ci
-description: Stages all changes, guards against unignored junk files, and generates a conventional commit. Triggered when the user runs /commit or asks to commit.
+description: Stages the changes produced in this session, excludes junk and secrets, and generates a conventional commit. Triggered when the user runs /devx-git:ci or asks to commit.
 model: sonnet
 allowed-tools: Bash(git:*)
 ---
 
 # Conventional Commit
 
+Be autonomous. Commit the work this session produced **without asking for confirmation**.
+Do not halt on junk or unrelated files — exclude them, commit the rest, and report.
+
 ## Workflow
 
-1. Run `git status --short` and inspect untracked files for paths that should never be committed (see Junk File Detection below).
-   - If any are found: **stop immediately**, list the offending paths, and tell the user they should probably add them to `.gitignore`. Do NOT stage or commit anything.
-   - If none are found: continue.
-
-2. Stage all changes and gather context:
+1. Survey the working tree:
    ```bash
-   git add -A
-   git diff --cached --stat
-   git diff --cached
+   git status --short
    git branch --show-current
    ```
 
-3. Analyze diff — determine type, scope, subject
+2. Decide what belongs in this commit (see Selecting Files below). Sort every dirty path
+   into one of four buckets:
+   - **Commit** — changes produced by the work done in this session (files you edited or
+     created, plus their direct byproducts like lockfiles, generated output, or migrations).
+   - **Exclude (secret)** — `.env`, keys, credentials. Never commit these; call them out
+     explicitly (see Junk & Secret Detection).
+   - **Exclude (junk)** — build artifacts, caches, dependencies, OS/editor cruft (see
+     Junk & Secret Detection).
+   - **Exclude (unrelated)** — pre-existing dirty files unrelated to this session's work.
 
-4. Commit immediately (no confirmation needed):
+3. Stage **only** the Commit bucket, with explicit pathspecs — never `git add -A` or `git add .`:
+   ```bash
+   git add -- <path1> <path2> ...
+   git diff --cached --stat
+   git diff --cached
+   ```
+
+4. Analyze the staged diff — determine type, scope, subject.
+
+5. Commit immediately (no confirmation needed). Add a second `-m` for a body when the
+   change is non-trivial:
    ```bash
    git commit -m "<type>(<scope>): <subject>"
    ```
 
-5. Show the commit hash and message summary
+6. Report:
+   - the commit hash and message,
+   - a short list of anything **excluded** and why — call out junk that should be added
+     to `.gitignore` and any secrets that were left uncommitted, as **information** for the
+     user. Do not block on these.
 
-## Junk File Detection
+## Selecting Files
 
-Before staging, scan `git status` output for untracked paths matching common junk patterns. If any match, **stop and instruct the user** to add the relevant rules to `.gitignore`.
+Prefer precision over completeness. The goal is a commit that matches the work you actually
+did this session.
 
-**Common patterns to watch for:**
+- **You have session context** (you edited files in this conversation): stage exactly those
+  files and their direct byproducts. Leave everything else for the user.
+- **No session context** (e.g. `/devx-git:ci` run cold at the start of a session): treat all dirty
+  tracked + untracked paths as the Commit bucket, minus anything caught by Junk & Secret
+  Detection.
+- **Ambiguous** (a dirty file might or might not relate to the work): if it plausibly belongs
+  to the change, include it; if it clearly doesn't, exclude it and mention it in the report.
+- **Distinct concerns** in one working tree: it's fine to stage only the cohesive subset that
+  forms one logical commit and tell the user what you left for a follow-up commit.
+
+## Junk & Secret Detection
+
+Never stage these, even if they appear to be part of the work. Exclude them and note them in
+the report.
+
+**Secrets** (call out explicitly — these are the important ones):
+`.env`, `.env.*`, `*.pem`, `*.key`, `id_rsa*`, `*credentials*`, `*.p12`, `*.keystore`
+
+**Junk / build / cache** (suggest adding to `.gitignore`):
 
 | Category | Paths |
 |----------|-------|
@@ -44,10 +82,10 @@ Before staging, scan `git status` output for untracked paths matching common jun
 | Go | `vendor/` (when go.sum exists) |
 | Rust | `target/` |
 | IDE/Editor | `.idea/`, `.vscode/`, `*.swp`, `*.swo`, `.DS_Store`, `Thumbs.db` |
-| Env/Secrets | `.env`, `.env.*`, `*.pem`, `*.key` |
 | General | `*.log`, `tmp/`, `.cache/` |
 
-This is not exhaustive. Apply judgment for any untracked directory that looks like build output, cache, or dependency vendoring.
+This is not exhaustive. Apply judgment for any untracked directory that looks like build
+output, cache, or dependency vendoring.
 
 ## Commit Message
 
@@ -56,6 +94,37 @@ Format: `<type>(<scope>): <subject>` — standard [Conventional Commits](https:/
 Types: `feat`, `fix`, `refactor`, `perf`, `test`, `docs`, `style`, `chore`, `build`.
 
 ## Examples
+
+### Selecting what to commit
+
+This session you implemented a rate limiter. `git status --short` shows a mix of your work,
+a secret, a dependency directory, and an unrelated pre-existing edit:
+
+```
+ M src/middleware/rateLimit.ts       # you wrote this
+ M src/server.ts                     # you wired it up here
+?? src/middleware/rateLimit.test.ts  # you added this test
+?? .env.local                        # secret, untouched by you
+?? node_modules/                     # dependency directory
+ M README.md                         # pre-existing edit, unrelated to this work
+```
+
+Sort the paths, then stage **only** the Commit bucket with explicit pathspecs:
+
+```bash
+git add -- src/middleware/rateLimit.ts src/server.ts src/middleware/rateLimit.test.ts
+git commit -m "feat(middleware): add sliding-window rate limiter"
+```
+
+Then report what was left out:
+
+> Committed `a1b2c3d` — feat(middleware): add sliding-window rate limiter
+> Left out:
+> - `.env.local` — looks like a secret; not committed. Add it to `.gitignore`.
+> - `node_modules/` — dependency directory; add it to `.gitignore`.
+> - `README.md` — modified but unrelated to this change; left for you.
+
+### Commit messages
 
 **Input** (diff stat):
 ```


### PR DESCRIPTION
## Summary
- The old `git add -A` + halt-on-junk design was a blunt instrument: one junk file in the working tree stopped the commit entirely, even when legitimate session work was ready to go
- Replaced with a four-bucket sort (commit / secret / junk / unrelated) and explicit `git add -- <paths>` scoped to the current session's work — junk and secrets are excluded and reported as information, never as blockers
- Synced the README to reflect the new autonomous behavior (was still describing manual staging with a confirmation step)

## Test plan
- [ ] Run `/devx-git:ci` in a repo where `node_modules/` or `.DS_Store` is untracked — should commit session work and report the junk, not block
- [ ] Run with a `.env` file present — should commit everything else and call out the secret explicitly
- [ ] Run with an unrelated pre-existing dirty file — should leave it out and mention it in the report
- [ ] Run cold (no session context) — should treat all non-junk dirty paths as the commit bucket