### PR TITLE
chore(devx-git): bump version to 2.1.2

### DIFF
--- a/plugins/git/.claude-plugin/plugin.json
+++ b/plugins/git/.claude-plugin/plugin.json
@@ -1,7 +1,7 @@
 {
   "name": "devx-git",
   "description": "Streamline your git workflow with simple commands for committing, creating pull requests, and updating branches via rebase",
-  "version": "2.1.1",
+  "version": "2.1.2",
   "author": {
     "name": "Pierre Tomasina",
     "email": "contact@dev3o.com"


### PR DESCRIPTION
## Summary
- Bump `devx-git` to 2.1.2 so the autonomous session-aware ci skill rewrite (#16) propagates to the plugin cache

## Test plan
- [ ] After release, reinstall/update the plugin and confirm `/devx-git:ci` no longer halts on junk and stages only session work